### PR TITLE
fix: wrong copy paste code, make filter work

### DIFF
--- a/noethysweb/parametrage/templates/parametrage/activite_liste1.html
+++ b/noethysweb/parametrage/templates/parametrage/activite_liste1.html
@@ -14,8 +14,8 @@
                 {% block box_introduction %}{{ box_introduction|safe }}{% endblock %}
                 {% block box_contenu %}
                     <div class="custom-control custom-checkbox custom-control-inline">
-                        <input type="checkbox" class="custom-control-input" id="id_check_attente" {% if afficher_renseignements_attente %}checked{% endif %}>
-                        <label class="custom-control-label" for="id_check_attente">Afficher les activités archivées</label>
+                        <input type="checkbox" class="custom-control-input" id="id_check_activites_archivees" {% if afficher_activites_archivees %}checked{% endif %}>
+                        <label class="custom-control-label" for="id_check_activites_archivees">Afficher les activités archivées</label>
                     </div>
                     <div class="mt-3"> <!-- Utilisation d'une marge top pour espacer le contenu -->
                     {% embed 'core/crud/liste.html' %}
@@ -32,14 +32,14 @@
     <script>
 
         $(document).ready(function() {
-            $("#id_check_attente").on('change', function () {
+            $("#id_check_activites_archivees").on('change', function () {
                 var etat = $(this)[0].checked;
                 $.ajax({
                     type: "POST",
                     url: "{% url 'ajax_memorise_parametre' %}",
                     data: {
-                        nom: "afficher_renseignements_attente",
-                        categorie: "renseignements_attente",
+                        nom: "afficher_activites_archivees",
+                        categorie: "activites_archivees",
                         valeur: etat,
                         csrfmiddlewaretoken: "{{ csrf_token }}",
                     },

--- a/noethysweb/parametrage/views/activites.py
+++ b/noethysweb/parametrage/views/activites.py
@@ -62,30 +62,33 @@ class Liste(Page, crud.Liste):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["afficher_renseignements_attente"] = self.afficher_renseignements_attente
+        context["afficher_activites_archivees"] = self.afficher_activites_archivees
         return context
 
     def get_queryset(self):
         user_structures = self.request.user.get_structures_all()
 
-        # Récupère toutes les activités avec objects_all et les structures filtrées
-        queryset = Activite.objects_all.prefetch_related("groupes_activites").filter(
-            self.Get_filtres("Q"),
-            structure__in=user_structures
-        )
-
-        # Détermine si les renseignements d'attente doivent être affichés
-        self.afficher_renseignements_attente = utils_parametres.Get(
-            nom="afficher_renseignements_attente",
-            categorie="renseignements_attente",
+        # Détermine si les activités archivées doivent être affichées
+        self.afficher_activites_archivees = utils_parametres.Get(
+            nom="afficher_activites_archivees",
+            categorie="activites_archivees",
             utilisateur=self.request.user,
             valeur=True
         )
 
-        if self.afficher_renseignements_attente:
+        if self.afficher_activites_archivees:
+            # Si les activités archivées doivent être affichées on se base sur objects_all
             queryset = Activite.objects_all.prefetch_related("groupes_activites").filter(
-                self.Get_filtres("Q"), structure__in=user_structures
-            ).annotate(nbre_inscrits=Count("inscription"))
+                self.Get_filtres("Q"),
+                structure__in=user_structures
+            )
+        else:
+            # Sinon, n'inclut pas les activités archivées
+            queryset = Activite.objects.prefetch_related("groupes_activites").filter(
+                self.Get_filtres("Q"),
+                structure__in=user_structures
+            )
+
         return queryset
 
     class datatable_class(MyDatatable):


### PR DESCRIPTION
PR pour l'issue #77 

Correction du filtre sur les activités archivées. Renommage des variables encore issues d'un ancien copié collé. 

Case décochée : 
<img width="1644" height="418" alt="image" src="https://github.com/user-attachments/assets/dd119bd3-8d30-48bb-add8-9c2d0bc96db7" />

Case cochée : 
<img width="1642" height="456" alt="image" src="https://github.com/user-attachments/assets/70624f73-560b-4cab-874d-858ad3252038" />

Le filtre automatique sur les structures à été conservé