### PR TITLE
Fix 500 lorsqu'on tente de masquer la colonne des checkbox dans les datatables

### DIFF
--- a/noethysweb/core/views/mydatatableview.py
+++ b/noethysweb/core/views/mydatatableview.py
@@ -61,6 +61,7 @@ class MyDatatable(Datatable):
         # Colonnes cachées mémorisées
         if parametres.get("hidden_columns", None):
             self._meta.hidden_columns = json.loads(parametres["hidden_columns"])
+            self._meta.hidden_columns = [col for col in self._meta.hidden_columns if col is not None]
 
         # Page length mémorisées
         if parametres.get("page_length", None):

--- a/noethysweb/versions.txt
+++ b/noethysweb/versions.txt
@@ -1,3 +1,6 @@
+Version 1.3.5.6.48 (05/05/2026)
+- Fix 500 lorsqu'on tente de masquer la colonne des checkbox dans les datatables
+
 Version 1.3.5.6.47 (31/03/2026)
 - Fix bug envoi de plusieurs mails (doublons) au directeur lors de l'inscription a une activité par les parents
 


### PR DESCRIPTION
Correspond aux erreurs de ces derniers jours

C'est un peu une rustine car on ne corrige pas le problème de fond, mais au moins ça ne plante plus