### PR TITLE
Add refusal modal and customizable email for refusals

### DIFF
--- a/noethysweb/outils/templates/outils/demandes_portail.html
+++ b/noethysweb/outils/templates/outils/demandes_portail.html
@@ -18,6 +18,36 @@
             {% endembed %}
         </div>
     </div>
+
+    {# Modal de refus d'inscription #}
+    <div class="modal fade" id="modal_refus_inscription" role="dialog" aria-labelledby="modal_refus_titre">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
+                <div class="modal-header bg-red">
+                    <h5 class="modal-title" id="modal_refus_titre"><strong>Refuser l'inscription</strong></h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>Un email de refus sera envoyé à la famille. Vous pouvez modifier le contenu ci-dessous :</p>
+                    <input type="hidden" id="refus_iddemande">
+                    <div class="form-group">
+                        <label for="refus_objet">Objet de l'email</label>
+                        <input type="text" class="form-control" id="refus_objet">
+                    </div>
+                    <div class="form-group">
+                        <label for="refus_corps">Corps de l'email</label>
+                        <textarea class="form-control" id="refus_corps" rows="8"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-ban margin-r-5"></i>Annuler</button>
+                    <button type="button" class="btn btn-danger" onclick="confirmer_refus()"><i class="fa fa-thumbs-down margin-r-5"></i>Confirmer le refus</button>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock contenu_page %}
 
 {% block scripts %}
@@ -71,6 +101,39 @@
                 }
             })
         };
+
+        function ouvrir_popup_refus(btn) {
+            var iddemande = $(btn).data('iddemande');
+            var nom = $(btn).data('nom');
+            var defaultBody = "Bonjour,\n\nLa demande d'inscription de " + nom + " vient d'être refusée par le directeur.\nPour plus d'informations, merci de le contacter directement.\n\nCordialement,\nL'équipe de Sacadoc";
+            $('#refus_iddemande').val(iddemande);
+            $('#refus_objet').val("Refus de votre inscription");
+            $('#refus_corps').val(defaultBody);
+            $('#modal_refus_inscription').modal('show');
+        }
+
+        function confirmer_refus() {
+            var iddemande = $('#refus_iddemande').val();
+            $.ajax({
+                type: "POST",
+                url: "{% url 'ajax_appliquer_modification_portail' %}",
+                data: {
+                    "iddemande": iddemande,
+                    "etat": "REFUS",
+                    "email_objet": $('#refus_objet').val(),
+                    "email_corps": $('#refus_corps').val()
+                },
+                datatype: "json",
+                success: function(data) {
+                    $('#modal_refus_inscription').modal('hide');
+                    var table = $('.datatable').DataTable();
+                    table.ajax.reload(null, false);
+                },
+                error: function(data) {
+                    toastr.error("Erreur");
+                }
+            });
+        }
 
         function tout_valider() {
             var listepk = get_coches();

--- a/noethysweb/outils/views/demandes_portail.py
+++ b/noethysweb/outils/views/demandes_portail.py
@@ -27,38 +27,39 @@ logger = logging.getLogger(__name__)
 
 def envoyer_email_refus(demande, email_objet=None, email_corps=None):
     """ Envoie un email si la demande est refusée """
-    print("Envoi d’un email de refus")
+    print("Envoi d'un email de refus")
 
     idadresse_exp = utils_portail.Get_parametre(code="connexion_adresse_exp")
     adresse_exp = AdresseMail.objects.filter(pk=idadresse_exp, actif=True).first()
     individu_f = Individu.objects.get(idindividu=demande.individu_id)
 
     if not adresse_exp:
-        logger.debug("Erreur : Pas d’adresse d’expédition paramétrée.")
-        return _("L’envoi de l’email a échoué. Merci de signaler cet incident à l’organisateur.")
+        logger.debug("Erreur : Pas d'adresse d'expédition paramétrée.")
+        return _("L'envoi de l'email a échoué. Merci de signaler cet incident à l'organisateur.")
 
     # Configuration du backend email
     backend = "django.core.mail.backends.console.EmailBackend"
     backend_kwargs = {}
 
-    if settings.EMAIL_BACKEND != "django.core.mail.backends.console.EmailBackend" and adresse_exp.moteur == "smtp":
-        backend = "django.core.mail.backends.smtp.EmailBackend"
-        backend_kwargs = {
-            "host": adresse_exp.hote,
-            "port": adresse_exp.port,
-            "username": adresse_exp.utilisateur,
-            "password": adresse_exp.motdepasse,
-            "use_tls": adresse_exp.use_tls
-        }
-    elif settings.EMAIL_BACKEND != "django.core.mail.backends.console.EmailBackend" and adresse_exp.moteur == "mailjet":
-        backend = "anymail.backends.mailjet.EmailBackend"
-        backend_kwargs = {
-            "api_key": adresse_exp.Get_parametre("api_key"),
-            "secret_key": adresse_exp.Get_parametre("api_secret"),
-        }
-    elif settings.EMAIL_BACKEND != "django.core.mail.backends.console.EmailBackend" and adresse_exp.moteur == "brevo":
-        backend = "anymail.backends.sendinblue.EmailBackend"
-        backend_kwargs = {"api_key": adresse_exp.Get_parametre("api_key")}
+    if not settings.DEBUG:
+        if adresse_exp.moteur == "smtp":
+            backend = "django.core.mail.backends.smtp.EmailBackend"
+            backend_kwargs = {
+                "host": adresse_exp.hote,
+                "port": adresse_exp.port,
+                "username": adresse_exp.utilisateur,
+                "password": adresse_exp.motdepasse,
+                "use_tls": adresse_exp.use_tls
+            }
+        elif adresse_exp.moteur == "mailjet":
+            backend = "anymail.backends.mailjet.EmailBackend"
+            backend_kwargs = {
+                "api_key": adresse_exp.Get_parametre("api_key"),
+                "secret_key": adresse_exp.Get_parametre("api_secret"),
+            }
+        elif adresse_exp.moteur == "brevo":
+            backend = "anymail.backends.sendinblue.EmailBackend"
+            backend_kwargs = {"api_key": adresse_exp.Get_parametre("api_key")}
 
     connection = djangomail.get_connection(backend=backend, fail_silently=False, **backend_kwargs)
     try:
@@ -68,14 +69,16 @@ def envoyer_email_refus(demande, email_objet=None, email_corps=None):
         return f"Connexion impossible au serveur de messagerie : {err}"
 
     # Création du message
-    objet = email_objet if email_objet else "Refus de votre inscription"
-    body = email_corps if email_corps else f"""Bonjour,
+    objet = email_objet.strip() if email_objet else "Refus de votre inscription"
+    activite_nom = demande.activite.nom if demande.activite else None
+    activite_str = f" à l'activité {activite_nom}" if activite_nom else ""
+    body = email_corps if (email_corps and email_corps.strip()) else f"""Bonjour,
 
-La demande d’inscription de {individu_f} vient d’être refusée par le directeur.
-Pour plus d’informations, merci de le contacter directement.
+La demande d'inscription de {individu_f}{activite_str} vient d'être refusée par le directeur.
+Pour plus d'informations, merci de le contacter directement.
 
 Cordialement,
-L’équipe de Sacadoc"""
+L'équipe de Sacadoc"""
 
     destinataire = demande.famille.mail
 
@@ -200,7 +203,7 @@ def Appliquer_modification(request):
     email_corps = request.POST.get("email_corps") or None
 
     # Importation et traitement de la demande
-    demande = PortailRenseignement.objects.select_related("famille", "individu").get(pk=iddemande)
+    demande = PortailRenseignement.objects.select_related("famille", "individu", "activite").get(pk=iddemande)
     redirection = Traiter_demande(request=request, demande=demande, etat=etat, email_objet=email_objet, email_corps=email_corps)
 
     return JsonResponse({"succes": True, "redirection": redirection})

--- a/noethysweb/outils/views/demandes_portail.py
+++ b/noethysweb/outils/views/demandes_portail.py
@@ -14,34 +14,35 @@ from core.models import PortailRenseignement, TypeSieste, Caisse, Individu, Sect
                         Medecin, ContactUrgence, Assurance, Information, QuestionnaireQuestion, Vaccin, Activite, Groupe,CategorieTarif, Inscription, AdresseMail
 from core.data import data_civilites
 from core.utils import utils_dates, utils_parametres
+from noethysweb import settings
 from portail.utils import utils_champs
 from django.core.mail import send_mail
 from django.core import mail as djangomail
 from django.core.mail import EmailMultiAlternatives
-from django.utils.html import strip_tags
+from django.utils.html import strip_tags, escape
 from core.utils import utils_portail
 import logging
 logger = logging.getLogger(__name__)
 
 
-def envoyer_email_refus(demande):
+def envoyer_email_refus(demande, email_objet=None, email_corps=None):
     """ Envoie un email si la demande est refusée """
-    print("Envoi d'un email de refus")
+    print("Envoi d’un email de refus")
 
     idadresse_exp = utils_portail.Get_parametre(code="connexion_adresse_exp")
     adresse_exp = AdresseMail.objects.filter(pk=idadresse_exp, actif=True).first()
     individu_f = Individu.objects.get(idindividu=demande.individu_id)
 
     if not adresse_exp:
-        logger.debug("Erreur : Pas d'adresse d'expédition paramétrée.")
-        return _("L'envoi de l'email a échoué. Merci de signaler cet incident à l'organisateur.")
+        logger.debug("Erreur : Pas d’adresse d’expédition paramétrée.")
+        return _("L’envoi de l’email a échoué. Merci de signaler cet incident à l’organisateur.")
 
     # Configuration du backend email
-    backend = 'django.core.mail.backends.console.EmailBackend'
+    backend = "django.core.mail.backends.console.EmailBackend"
     backend_kwargs = {}
 
-    if adresse_exp.moteur == "smtp":
-        backend = 'django.core.mail.backends.smtp.EmailBackend'
+    if settings.EMAIL_BACKEND != "django.core.mail.backends.console.EmailBackend" and adresse_exp.moteur == "smtp":
+        backend = "django.core.mail.backends.smtp.EmailBackend"
         backend_kwargs = {
             "host": adresse_exp.hote,
             "port": adresse_exp.port,
@@ -49,14 +50,14 @@ def envoyer_email_refus(demande):
             "password": adresse_exp.motdepasse,
             "use_tls": adresse_exp.use_tls
         }
-    elif adresse_exp.moteur == "mailjet":
-        backend = 'anymail.backends.mailjet.EmailBackend'
+    elif settings.EMAIL_BACKEND != "django.core.mail.backends.console.EmailBackend" and adresse_exp.moteur == "mailjet":
+        backend = "anymail.backends.mailjet.EmailBackend"
         backend_kwargs = {
             "api_key": adresse_exp.Get_parametre("api_key"),
             "secret_key": adresse_exp.Get_parametre("api_secret"),
         }
-    elif adresse_exp.moteur == "brevo":
-        backend = 'anymail.backends.sendinblue.EmailBackend'
+    elif settings.EMAIL_BACKEND != "django.core.mail.backends.console.EmailBackend" and adresse_exp.moteur == "brevo":
+        backend = "anymail.backends.sendinblue.EmailBackend"
         backend_kwargs = {"api_key": adresse_exp.Get_parametre("api_key")}
 
     connection = djangomail.get_connection(backend=backend, fail_silently=False, **backend_kwargs)
@@ -67,16 +68,14 @@ def envoyer_email_refus(demande):
         return f"Connexion impossible au serveur de messagerie : {err}"
 
     # Création du message
-    objet = "Refus de votre inscription"
-    body = f"""
-Bonjour,
+    objet = email_objet if email_objet else "Refus de votre inscription"
+    body = email_corps if email_corps else f"""Bonjour,
 
-La demande d'inscription de {individu_f} vient d'être refusée par le directeur.
+La demande d’inscription de {individu_f} vient d’être refusée par le directeur.
 Pour plus d’informations, merci de le contacter directement.
 
 Cordialement,
-L’équipe de Sacadoc
-"""
+L’équipe de Sacadoc"""
 
     destinataire = demande.famille.mail
 
@@ -103,7 +102,7 @@ L’équipe de Sacadoc
 
     connection.close()
 
-def Traiter_demande(request=None, demande=None, etat=None):
+def Traiter_demande(request=None, demande=None, etat=None, email_objet=None, email_corps=None):
     """ Traitement d'une demande donnée """
     redirection = None
 
@@ -185,7 +184,7 @@ def Traiter_demande(request=None, demande=None, etat=None):
                 return redirection
 
     if etat == "REFUS":
-        envoyer_email_refus(demande)
+        envoyer_email_refus(demande, email_objet=email_objet, email_corps=email_corps)
         # Modifie l'état de la demande
         demande.traitement_date = datetime.datetime.now()
         demande.traitement_utilisateur = request.user
@@ -197,10 +196,12 @@ def Traiter_demande(request=None, demande=None, etat=None):
 def Appliquer_modification(request):
     iddemande = int(request.POST["iddemande"])
     etat = request.POST["etat"]
+    email_objet = request.POST.get("email_objet") or None
+    email_corps = request.POST.get("email_corps") or None
 
     # Importation et traitement de la demande
     demande = PortailRenseignement.objects.select_related("famille", "individu").get(pk=iddemande)
-    redirection = Traiter_demande(request=request, demande=demande, etat=etat)
+    redirection = Traiter_demande(request=request, demande=demande, etat=etat, email_objet=email_objet, email_corps=email_corps)
 
     return JsonResponse({"succes": True, "redirection": redirection})
 
@@ -404,7 +405,8 @@ class Liste(Page, crud.Liste):
                 if instance.etat in ("ATTENTE", "REFUS"):
                     html.append("""<button class='btn btn-success btn-xs' onclick="traiter_demande(%d, 'VALIDE')" title='Valider'><i class="fa fa-fw fa-thumbs-up"></i></button>""" % instance.pk)
                 if instance.etat in ("ATTENTE", "VALIDE"):
-                    html.append("""<button class='btn btn-danger btn-xs' onclick="traiter_demande(%d, 'REFUS')" title='Refuser'><i class="fa fa-fw fa-thumbs-down"></i></button>""" % instance.pk)
+                    nom_individu = escape(instance.individu.Get_nom()) if instance.individu else "l&#39;individu"
+                    html.append("""<button class='btn btn-danger btn-xs' title='Refuser' data-iddemande="%d" data-nom="%s" onclick="ouvrir_popup_refus(this)"><i class="fa fa-fw fa-thumbs-down"></i></button>""" % (instance.pk, nom_individu))
             return self.Create_boutons_actions(html)
 
         def Get_actions(self, instance, *args, **kwargs):


### PR DESCRIPTION
Wire modal and JS to send custom subject/body to Appliquer_modification. Pass email_objet/email_corps through Traiter_demande to envoyer_email_refus.
Respect settings for email backend selection and escape names in the button.

implements #132 