### PR TITLE
Validate email domains with MX lookup

### DIFF
--- a/noethysweb/core/validators.py
+++ b/noethysweb/core/validators.py
@@ -6,6 +6,7 @@ import dns.exception
 
 
 def validate_email_domain_mx(value):
+    """Vérifie que le domaine de l'adresse email possède un enregistrement MX (ou A en fallback RFC 5321). Fail-open sur erreur réseau."""
     if not value or "@" not in value:
         return
     domain = value.rsplit("@", 1)[1].lower()

--- a/noethysweb/core/validators.py
+++ b/noethysweb/core/validators.py
@@ -1,0 +1,33 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+import dns.resolver
+import dns.exception
+
+
+def validate_email_domain_mx(value):
+    if not value or "@" not in value:
+        return
+    domain = value.rsplit("@", 1)[1].lower()
+    try:
+        dns.resolver.resolve(domain, "MX")
+        return
+    except dns.resolver.NXDOMAIN:
+        raise ValidationError(
+            _("Le domaine « %(domain)s » n'existe pas. Vérifiez l'adresse email saisie."),
+            params={"domain": domain},
+        )
+    except dns.resolver.NoAnswer:
+        # Pas de MX — essai fallback A record (RFC 5321)
+        try:
+            dns.resolver.resolve(domain, "A")
+            return
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+            raise ValidationError(
+                _("Le domaine « %(domain)s » ne peut pas recevoir d'emails. Vérifiez l'adresse saisie."),
+                params={"domain": domain},
+            )
+        except dns.exception.DNSException:
+            return  # Fail open sur erreur réseau
+    except dns.exception.DNSException:
+        return  # Fail open sur erreur réseau (timeout, etc.)

--- a/noethysweb/parametrage/forms/adresses_mail.py
+++ b/noethysweb/parametrage/forms/adresses_mail.py
@@ -11,6 +11,7 @@ from crispy_forms.layout import Layout, HTML, Fieldset
 from crispy_forms.bootstrap import Field
 from core.utils.utils_commandes import Commandes
 from core.models import AdresseMail
+from core.validators import validate_email_domain_mx
 
 
 class Formulaire(FormulaireBase, ModelForm):
@@ -90,6 +91,12 @@ class Formulaire(FormulaireBase, ModelForm):
         # Vérification des données saisies
         if not self.cleaned_data.get("adresse", None):
             self.add_error('adresse', "Vous devez renseigner l'adresse d'expédition")
+            return
+
+        try:
+            validate_email_domain_mx(self.cleaned_data["adresse"])
+        except forms.ValidationError as e:
+            self.add_error('adresse', e)
             return
 
         if self.cleaned_data["moteur"] == "smtp":

--- a/noethysweb/parametrage/forms/adresses_mail.py
+++ b/noethysweb/parametrage/forms/adresses_mail.py
@@ -87,16 +87,16 @@ class Formulaire(FormulaireBase, ModelForm):
             HTML(EXTRA_SCRIPT),
         )
 
+    def clean_adresse(self):
+        adresse = self.cleaned_data.get("adresse", "")
+        if adresse:
+            validate_email_domain_mx(adresse)
+        return adresse
+
     def clean(self):
         # Vérification des données saisies
         if not self.cleaned_data.get("adresse", None):
             self.add_error('adresse', "Vous devez renseigner l'adresse d'expédition")
-            return
-
-        try:
-            validate_email_domain_mx(self.cleaned_data["adresse"])
-        except forms.ValidationError as e:
-            self.add_error('adresse', e)
             return
 
         if self.cleaned_data["moteur"] == "smtp":

--- a/noethysweb/portail/forms/individu_coords.py
+++ b/noethysweb/portail/forms/individu_coords.py
@@ -10,6 +10,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML
 from core.models import Individu, Rattachement
 from core.forms.select2 import Select2Widget
+from core.validators import validate_email_domain_mx
 from core.widgets import Telephone, CodePostal, Ville
 from portail.forms.fiche import FormulaireBase
 
@@ -91,6 +92,18 @@ class Formulaire(FormulaireBase, ModelForm):
         # Finalisation du layout
         self.Set_layout()
         self.helper.layout.append(HTML(EXTRA_SCRIPT))
+
+    def clean_mail(self):
+        value = self.cleaned_data.get("mail")
+        if value:
+            validate_email_domain_mx(value)
+        return value
+
+    def clean_travail_mail(self):
+        value = self.cleaned_data.get("travail_mail")
+        if value:
+            validate_email_domain_mx(value)
+        return value
 
     def clean(self):
         # Adresse auto

--- a/noethysweb/portail/forms/inscription.py
+++ b/noethysweb/portail/forms/inscription.py
@@ -1,5 +1,6 @@
 from core.data import data_civilites
 from core.models import Utilisateur
+from core.validators import validate_email_domain_mx
 from django import forms
 from django.contrib.auth.forms import SetPasswordForm
 from django.utils.translation import gettext_lazy as _
@@ -12,7 +13,7 @@ class InscriptionFamilleForm(SetPasswordForm):
     )
     nom = forms.CharField(label=_("Nom"), max_length=200)
     prenom = forms.CharField(label=_("Prénom"), max_length=200)
-    mail = forms.EmailField(label=_("Email personnel"), max_length=300)
+    mail = forms.EmailField(label=_("Email personnel"), max_length=300, validators=[validate_email_domain_mx])
     turnstile = TurnstileField()
 
 

--- a/noethysweb/portail/views/famille_parent.py
+++ b/noethysweb/portail/views/famille_parent.py
@@ -10,6 +10,7 @@ from core.models import (
     Rattachement,
 )
 from core.utils import utils_questionnaires
+from core.validators import validate_email_domain_mx
 from django import forms
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Submit, Div, HTML, Fieldset
@@ -48,7 +49,7 @@ class IndividuForm(forms.ModelForm):
     tel_mobile = forms.CharField(
         required=False, label="Téléphone portable", max_length=100
     )
-    mail = forms.EmailField(required=False, label="Email personnel", max_length=300)
+    mail = forms.EmailField(required=False, label="Email personnel", max_length=300, validators=[validate_email_domain_mx])
 
     # Numéro de sécurité sociale
     secu = forms.CharField(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ certifi==2023.5.7
 cffi==1.15.1
 charset-normalizer==3.1.0
 click==8.1.3
-colorama==0.4.6 ; sys_platform == 'win32'
 colorhash==1.2.1
 cryptography==40.0.2
 django==3.2.19
@@ -74,14 +73,12 @@ requests==2.30.0
 requests-file==1.5.1
 requests-toolbelt==1.0.0
 rlpycairo==0.2.0
-setuptools==81.0.0
 sgmllib3k==1.0.0
 six==1.16.0
 soupsieve==2.4.1
 sqlparse==0.4.4
 stone==3.3.1
 stripe==14.3.0
-text-unidecode==1.3
 tomli==2.3.0
 typing-extensions==4.12.2
 urllib3==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ certifi==2023.5.7
 cffi==1.15.1
 charset-normalizer==3.1.0
 click==8.1.3
+colorama==0.4.6 ; sys_platform == 'win32'
 colorhash==1.2.1
 cryptography==40.0.2
 django==3.2.19
@@ -31,6 +32,7 @@ django-sn==0.8.11.9
 django-storages==1.13.1
 django-turnstile==0.1.3
 django-upload-form==0.5.0
+dnspython==2.8.0
 docx-mailmerge2==0.8.0
 dropbox==12.0.2
 eopayment==1.79
@@ -63,11 +65,6 @@ pyee==13.0.0
 pygments==2.19.2
 pypdf==5.1.0
 pystrich==0.9
-pytest==8.4.2
-pytest-base-url==2.1.0
-pytest-django==4.11.1
-pytest-mock==3.15.1
-pytest-playwright==0.7.1
 python-dateutil==2.8.2
 python-gnupg==0.4.7
 python-slugify==8.0.4
@@ -77,11 +74,14 @@ requests==2.30.0
 requests-file==1.5.1
 requests-toolbelt==1.0.0
 rlpycairo==0.2.0
+setuptools==81.0.0
 sgmllib3k==1.0.0
 six==1.16.0
 soupsieve==2.4.1
 sqlparse==0.4.4
 stone==3.3.1
+stripe==14.3.0
+text-unidecode==1.3
 tomli==2.3.0
 typing-extensions==4.12.2
 urllib3==2.0.2
@@ -89,4 +89,3 @@ webencodings==0.5.1
 xlrd==2.0.1
 xlsxwriter==3.1.9
 zeep==4.2.1
-stripe==14.3.0


### PR DESCRIPTION
Add a validator that checks domain MX records and falls back to an A record per RFC 5321. Network/DNS errors are treated as fail-open. Apply the validator to email fields in adresses_mail, individu, inscription and famille_parent forms.

Fix #133 