### PR TITLE
Afficher les formulaires d'articles comme alertes sur l'accueil portail

### DIFF
--- a/noethysweb/portail/templates/portail/accueil.html
+++ b/noethysweb/portail/templates/portail/accueil.html
@@ -35,7 +35,7 @@
 
 
     {# Notifications #}
-    {% if approbations_requises or nbre_messages_non_lus or nbre_pieces_manquantes or nbre_renseignements_manquants or nbre_questionnaires_manquants or nbre_vaccinations_manquantes or nbre_verifications_manquante or nbre_assurances_manquantes or cotisations_manquantes or nbre_sondages_manquants %}
+    {% if approbations_requises or nbre_messages_non_lus or nbre_pieces_manquantes or nbre_renseignements_manquants or nbre_questionnaires_manquants or nbre_vaccinations_manquantes or nbre_verifications_manquante or nbre_assurances_manquantes or cotisations_manquantes or nbre_sondages_manquants or nbre_formulaires_manquants %}
 
         <h5 class="mb-2 text-secondary">{% blocktrans %}Alertes{% endblocktrans %}</h5>
         <div class="row mb-2">
@@ -216,6 +216,22 @@
                             </p>
                         </div>
                         <div class="icon"><i class="fa fa-file-text-o"></i></div>
+                        <a href="{% url 'portail_sondages' %}" class="small-box-footer">{% trans "Consulter" %} <i class="fa fa-arrow-circle-right"></i></a>
+                    </div>
+                </div>
+            {% endif %}
+
+            {# Formulaires manquants (articles avec sondage non répondu) #}
+            {% if nbre_formulaires_manquants %}
+                <div class="col-lg-3 col-6">
+                    <div class="small-box bg-warning">
+                        <div class="inner">
+                            <h3>{{ nbre_formulaires_manquants }}</h3>
+                            <p>
+                                {% blocktranslate count counter=nbre_formulaires_manquants %}Formulaire à compléter{% plural %}Formulaires à compléter{% endblocktranslate %}
+                            </p>
+                        </div>
+                        <div class="icon"><i class="fa fa-wpforms"></i></div>
                         <a href="{% url 'portail_sondages' %}" class="small-box-footer">{% trans "Consulter" %} <i class="fa fa-arrow-circle-right"></i></a>
                     </div>
                 </div>

--- a/noethysweb/portail/views/accueil.py
+++ b/noethysweb/portail/views/accueil.py
@@ -10,7 +10,7 @@ from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
-from core.models import Article, Consommation, Inscription, Lecture, PortailMessage
+from core.models import Article, Consommation, Inscription, Lecture, PortailMessage, SondageRepondant
 from cotisations.utils import utils_cotisations_manquantes
 from individus.utils import (
     utils_assurances,
@@ -114,7 +114,28 @@ class Accueil(CustomView, TemplateView):
                 selection_articles.append(article)
                 if article.texte_popup:
                     popups.append(article)
-        context['articles'] = selection_articles
+        # Séparer les articles avec formulaire (sondage) non répondu → alertes
+        sondages_des_articles = [a.sondage for a in selection_articles if a.sondage]
+        if sondages_des_articles:
+            sondages_repondus = set(
+                SondageRepondant.objects.filter(
+                    sondage__in=sondages_des_articles,
+                    famille=self.request.user.famille,
+                ).values_list('sondage_id', flat=True)
+            )
+        else:
+            sondages_repondus = set()
+
+        articles_normaux = []
+        nbre_formulaires_manquants = 0
+        for article in selection_articles:
+            if article.sondage and article.sondage.idsondage not in sondages_repondus:
+                nbre_formulaires_manquants += 1
+            else:
+                articles_normaux.append(article)
+
+        context['articles'] = articles_normaux
+        context['nbre_formulaires_manquants'] = nbre_formulaires_manquants
 
         # Popups
         context['articles_popups'] = []


### PR DESCRIPTION
## Résumé

Closes #134

- Les articles liés à un sondage (formulaire) non encore complété par la famille apparaissent désormais dans la section **Alertes** de l'accueil portail, plutôt que dans Actualités.
- Une fois le formulaire rempli, l'article repasse en Actualités comme un article normal.
- La section Alertes s'affiche bien dès qu'il y a au moins un formulaire à compléter.

## Plan de test

- [ ] Créer un article avec un sondage attaché → vérifier qu'il apparaît dans Alertes (boîte « Formulaire à compléter ») et non dans Actualités
- [ ] Répondre au sondage → vérifier que l'article disparaît des Alertes et réapparaît dans Actualités
- [ ] Vérifier qu'un article sans sondage continue d'apparaître uniquement dans Actualités