### PR TITLE
test(portail): portal test suite

### DIFF
--- a/noethysweb/tests/portail/TEST_PLAN.md
+++ b/noethysweb/tests/portail/TEST_PLAN.md
@@ -1,0 +1,107 @@
+# Portail test plan & progress tracker
+
+The `portail` app is the family self-service portal (`request.user.categorie == "famille"`)
+— the only interface exposed to external non-staff users, so the most security-sensitive
+surface of Noethysweb. ~70 routes, currently only one test (`test_signin.py`).
+
+**Goal:** comprehensive coverage of every page and functionality.
+**Approach:** layered — fast Django-test-client **integration** tests for breadth +
+**Playwright E2E** for critical real-browser flows.
+**Out of scope:** payment gateway internals (Payzen/PayFip/HelloAsso/Stripe/TPE return
+handlers, IPN callbacks). Billing/receipt *pages* are still covered.
+
+> ⚠️ **Tests are not expected to all pass on first write.** There are known bugs in the
+> portail. A failing test may be surfacing a real bug — when that happens, record it under
+> "Bugs found" below and leave the test failing (or `xfail` with a reference) rather than
+> weakening the assertion to force green. The point of this suite is partly to *find* these.
+
+> **Status: implemented.** 229 tests pass, 5 `xfail(strict)` mark the 4 documented bugs.
+> Test files use a `test_portail_*` prefix because pytest's prepend import mode requires
+> globally-unique module basenames (a bare `test_auth.py` collides with
+> `tests/integration/test_auth.py`). No `__init__.py` under `tests/portail/` — that would
+> shadow the real `portail` app package.
+
+---
+
+## Phase 0 — Foundations (unblocks everything) ✅
+
+- [x] Expanded `tests/unit/factories.py`: `IndividuFactory`, `RattachementFactory`,
+      `ActiviteFactory`, `GroupeFactory`, `InscriptionFactory`, `TypePieceFactory`,
+      `PieceFactory`, `PortailMessageFactory`, `SondageFactory`, `FactureFactory`,
+      and `create_famille_complete()` helper (famille + titulaire individu + child).
+      (`ReglementFactory`/`PrestationFactory` skipped — heavy FK graph; billing covered
+      via empty-state + `Facture`.)
+- [x] Added `tests/portail/conftest.py`: `famille_user`, `other_famille`, `staff_user`,
+      `organisateur` (pk=1), `logged_client`, autouse `clear_cache`.
+      (`PortailParametre` seeding unnecessary — `utils_portail.Get_dict_parametres()`
+      returns working defaults.)
+
+## Phase 1 — Authorization suite (highest priority) ✅ — `test_portail_authorization.py` (54 tests)
+
+- [x] Unauthenticated access → redirect to `portail_connexion` (all simple + rattachement routes).
+- [x] Staff user (`categorie="utilisateur"`) blocked by `CustomView.test_func()` — 403 (accueil → 302).
+- [x] Cross-family isolation: family A → family B's `idrattachement` returns 403 (15 routes); own access 200.
+- [x] AJAX endpoint probes — `test_portail_ajax_authorization.py` (49 tests): all 16 `@secure_ajax_portail`
+      endpoints reject anonymous (403), staff (403) and non-AJAX (400); famille positive case clears the decorator.
+
+## Phase 2 — Integration breadth (`tests/portail/integration/`) ✅
+
+- [x] `test_portail_auth.py` — reset/done pages, inscription_famille, profil, profil_password_change, deconnexion
+- [x] `test_portail_accueil.py` — dashboard render + unread-message count
+- [x] `test_portail_pages.py` — render-smoke for all 13 no-arg pages + cotisations
+- [x] `test_portail_renseignements.py` — all individu consulter/modifier fiches + famille fiches; identite save
+- [x] `test_portail_individu_crud.py` — contacts add (POST creates) + delete (POST removes)
+- [x] `test_portail_membres.py` — add child (creates Individu+Rattachement), add parent form
+- [x] `test_portail_activites.py` — activites list + shows inscription, inscrire form, cotisations
+- [x] `test_portail_documents.py` — documents list, piece listing, upload form, supprimer_piece (+security xfails)
+- [x] `test_portail_billing.py` — facturation (empty + with Facture), reglements, payzen return pages
+- [x] `test_portail_surveys.py` — sondage intro/questions/conclusion + POST saves repondant/response
+- [x] `test_portail_contact.py` — contact hub + conversation (marks read), messagerie send
+- [x] `test_portail_misc.py` — mentions, desinscription, album (valid code)
+- [x] `test_portail_reservations.py` — reservations list, planning render + test_func authorization (no inscription / cross-family → 403)
+- [x] `test_portail_wizard.py` — inscription AJAX steps: get_activites_par_structure, get_form_extra, valid_form (invalid → 400)
+
+## Phase 3 — E2E flows (`tests/portail/e2e/`, Playwright + `auto_login_user`) ✅
+
+- [x] `test_portail_e2e_navigation.py` — dashboard + navigate main pages, no server error
+- [x] `test_portail_e2e_add_child.py` — add-child form submission creates Individu
+- [x] `test_portail_e2e_edit_identite.py` — edit child identity, change persists (validation workflow)
+- [x] Login/logout + registration already covered by `tests/test_login.py` and `tests/portail/test_signin.py`
+- [x] `test_portail_e2e_messagerie.py` — post a message via the summernote editor
+- [x] `test_portail_e2e_document_upload.py` — upload a file (file input) → Piece created
+- [x] `test_portail_e2e_inscription_wizard.py` — structure→activité AJAX cascade populates the dropdown
+- [x] `test_portail_e2e_planning.py` — reservation planning grid renders in-browser
+
+## Remaining / deferred
+
+- Planning grid **cell-toggle + Save_grille** submission (needs Unite/tariff object graph + grille JS internals) —
+  the planning E2E currently verifies render only.
+- Full inscription **Valid_form** happy-path (creates the demande) — needs the tariff/pieces object graph; the
+  wizard tests cover the AJAX cascade and the invalid→400 path.
+- `Reglement`-populated reglements page (needs ModeReglement/Payeur/CompteBancaire/ModeleImpression factories).
+
+---
+
+## Verification commands
+
+```bash
+uv run pytest noethysweb/tests/portail/ -v
+uv run pytest noethysweb/tests/portail/integration/test_authorization.py -v
+HEADLESS=1 uv run pytest noethysweb/tests/portail/e2e/ -v
+uv run pytest            # full suite
+uvx ruff check . && uvx ruff format --check .
+```
+
+---
+
+## Bugs found
+
+_Document failing tests that reveal real bugs here (route, expected vs actual, test name)._
+
+| # | Route / area | Test | Symptom | Status |
+|---|---|---|---|---|
+| 1 | `portail_famille_parametres_modifier` (famille_parametres.Modifier) | `test_portail_renseignements.py::test_famille_parametres_modifier_renders` | **500 Internal Server Error.** `utils_onglets.py:27` has the `famille_parametres` onglet commented out, so `Get_onglet("famille_parametres")` returns `None` and `famille_parametres.py:37` raises `AttributeError: 'NoneType' object has no attribute 'validation_auto'`. The Consulter page works; only Modifier crashes. Fix: uncomment the onglet (or guard the `None` case). | xfail(strict) — open |
+| 2 | `supprimer_piece` (documents.py:75) | `test_portail_documents.py::test_anonymous_cannot_delete_piece`, `test_cannot_delete_other_family_piece` | **Security: missing auth + ownership check.** Plain function view with no `@login_required` and no famille check — `get_object_or_404(Piece, pk)` then deletes on POST. Any anonymous user can delete any `Piece` by pk; any family can delete another family's pieces. Fix: require login + verify the piece belongs to `request.user.famille`. | 2× xfail(strict) — open |
+| 3 | `supprimer_piece` GET (documents.py:81) | `test_portail_documents.py::test_confirmation_page_renders_for_owner` | **500.** GET renders `core/confirmation_suppression.html`, which does not exist anywhere → `TemplateDoesNotExist`. The confirmation page is unreachable; only direct POST works. Fix: add the template or point to an existing one. | xfail(strict) — open |
+| 4 | `portail_documents_modifier` (transmettre_piece.Modifier, documents/forms `Modifier.get_queryset`) | `test_portail_documents.py::TestModifierPiece::test_cannot_open_other_family_piece` | **Security (low impact): missing ownership check.** `get_queryset` returns `Piece.objects.filter(pk=self.kwargs["pk"])` with **no famille filter**, despite a comment claiming "l'utilisateur ne peut modifier que ses propres documents". Family A can open/modify family B's piece via `/documents/modifier/<pk>/`. Impact is **metadata-only** (title/dates/individu): the edit form uses a `FileInput` widget and renders no link to the stored file, so document content is *not* exposed via this route (that is finding #5). Fix: add `famille=self.request.user.famille` to the queryset filter. | xfail(strict) — open |
+| 5 | Private media serving (`MEDIA_URL=/media/`, `Piece.document` storage `get_storage("piece")`, `get_uuid_path` at `core/models.py:261`) | _Not Django-testable — infra/reverse-proxy concern, documented here only_ | **Security (high impact): unauthenticated file access.** Uploaded family documents are stored at `pieces/<uuid>.<ext>` and served directly off disk by the reverse proxy under `/media/`. Django auth never runs, so anyone with a file URL (guessed, leaked via logs/Referer/email, or shared) can download any family's documents with no login. The UUID filename is obscurity, not access control — and if nginx has `autoindex on` for the media location the UUIDs are enumerable. Fix: stop serving private files directly; route through an authenticated Django view that checks `request.user.famille` ownership and hands off via `X-Accel-Redirect` / `django-sendfile2`. | infra — open |

--- a/noethysweb/tests/portail/conftest.py
+++ b/noethysweb/tests/portail/conftest.py
@@ -1,0 +1,59 @@
+"""Shared fixtures for the family portal (`portail`) test suite.
+
+The portal is the only interface exposed to external non-staff users, so these
+fixtures build realistic families and keep the per-request caches clean between
+tests (portail/views/base.py caches `parametres_portail`, `organisateur` and the
+interface options in the Django cache, which would otherwise leak across tests).
+"""
+
+import pytest
+from django.core.cache import cache
+
+from tests.unit.factories import (
+    OrganisateurFactory,
+    UtilisateurFactory,
+    create_famille_complete,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """base.py caches portail params/organisateur — clear before & after each test."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def organisateur(db):
+    """Most portail pages read Organisateur pk=1 (cached in base.py)."""
+    return OrganisateurFactory(pk=1)
+
+
+@pytest.fixture
+def famille_user(db, organisateur):
+    """A complete portail family: (user, famille, rattachements).
+
+    rattachements[0] is the titulaire adult, rattachements[1] the child.
+    """
+    return create_famille_complete(username="famille_a")
+
+
+@pytest.fixture
+def other_famille(db, organisateur):
+    """A second, unrelated family — used for cross-family authorization tests."""
+    return create_famille_complete(username="famille_b")
+
+
+@pytest.fixture
+def staff_user(db):
+    """A staff (categorie='utilisateur') user — must be denied on portail routes."""
+    return UtilisateurFactory(username="staff_member")
+
+
+@pytest.fixture
+def logged_client(client, famille_user):
+    """A Django test client already logged in as the famille portail user."""
+    user, _famille, _ratt = famille_user
+    client.force_login(user)
+    return client

--- a/noethysweb/tests/portail/e2e/test_portail_e2e_add_child.py
+++ b/noethysweb/tests/portail/e2e/test_portail_e2e_add_child.py
@@ -1,0 +1,23 @@
+"""E2E: a family adds a child through the portal form in a real browser."""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from core.models import Individu
+
+
+@pytest.mark.django_db
+def test_add_child_flow(auto_login_user, famille_user, live_server, page: Page):
+    user, famille, _ratt = famille_user
+    page = auto_login_user(user)
+
+    page.goto(f"{live_server.url}/individu/ajouter/")
+
+    page.locator("#id_prenom").fill("Lucie")
+    page.locator("#id_nom").fill("Browser")
+    page.locator("#id_date_naiss").fill("2017-03-04")
+    page.get_by_role("button", name="Enregistrer").click()
+
+    # Redirects to the renseignements page on success.
+    expect(page).to_have_url(f"{live_server.url}/renseignements")
+    assert Individu.objects.filter(prenom="Lucie", nom="Browser").exists()

--- a/noethysweb/tests/portail/e2e/test_portail_e2e_document_upload.py
+++ b/noethysweb/tests/portail/e2e/test_portail_e2e_document_upload.py
@@ -1,0 +1,34 @@
+"""E2E: a family uploads a document (file input) through the portal."""
+
+import base64
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from core.models import Piece
+
+# 1x1 transparent PNG.
+PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.mark.django_db
+def test_upload_document_flow(auto_login_user, famille_user, live_server, page: Page):
+    user, famille, _ratt = famille_user
+    page = auto_login_user(user)
+
+    page.goto(f"{live_server.url}/documents/transmettre")
+
+    # With no missing pieces, the only choice is "Un autre type de pièce" (value 9999),
+    # which reveals the titre field via the page's change handler.
+    page.select_option("#id_selection_piece", "9999")
+    page.fill("#id_titre", "Certificat E2E")
+    page.set_input_files(
+        "#id_document",
+        files=[{"name": "justif.png", "mimeType": "image/png", "buffer": PNG_BYTES}],
+    )
+    page.get_by_role("button", name="Envoyer").click()
+
+    expect(page).to_have_url(f"{live_server.url}/renseignements")
+    assert Piece.objects.filter(famille=famille, titre="Certificat E2E").exists()

--- a/noethysweb/tests/portail/e2e/test_portail_e2e_edit_identite.py
+++ b/noethysweb/tests/portail/e2e/test_portail_e2e_edit_identite.py
@@ -1,0 +1,24 @@
+"""E2E: a family edits a child's identity through the portal in a real browser."""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.django_db
+def test_edit_child_identity(auto_login_user, famille_user, live_server, page: Page):
+    user, _famille, ratt = famille_user
+    enfant = ratt[1].individu
+    page = auto_login_user(user)
+
+    page.goto(
+        f"{live_server.url}/renseignements/individu/identite/modifier/{ratt[1].pk}"
+    )
+    page.locator("#id_nom").fill("NomModifieBrowser")
+    page.get_by_role("button", name="Enregistrer").click()
+
+    # Leaves the edit form (validation_auto=True persists the change directly).
+    expect(page).not_to_have_url(
+        f"{live_server.url}/renseignements/individu/identite/modifier/{ratt[1].pk}"
+    )
+    enfant.refresh_from_db()
+    assert enfant.nom == "NomModifieBrowser"

--- a/noethysweb/tests/portail/e2e/test_portail_e2e_inscription_wizard.py
+++ b/noethysweb/tests/portail/e2e/test_portail_e2e_inscription_wizard.py
@@ -1,0 +1,31 @@
+"""E2E: the inscription wizard's structure -> activité AJAX cascade.
+
+The full submission (tarifs + pieces via Valid_form) needs the whole tariff
+object graph; this verifies the key in-browser behaviour: choosing a structure
+populates the activity dropdown via AJAX (get_activites_par_structure).
+"""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.unit.factories import ActiviteFactory, GroupeFactory, StructureFactory
+
+
+@pytest.mark.django_db
+def test_structure_change_populates_activities(
+    auto_login_user, famille_user, live_server, page: Page
+):
+    user, _famille, _ratt = famille_user
+    structure = StructureFactory(visible=True)
+    activite = ActiviteFactory(structure=structure, visible=True, nom="Camp Été")
+    GroupeFactory(activite=activite)
+
+    page = auto_login_user(user)
+    page.goto(f"{live_server.url}/activites/inscrire")
+
+    page.select_option("#id_structure", str(structure.pk))
+
+    # The change handler AJAX-loads the activities into #id_activite.
+    option = page.locator(f"#id_activite option[value='{activite.pk}']")
+    expect(option).to_have_count(1)
+    expect(option).to_have_text("Camp Été")

--- a/noethysweb/tests/portail/e2e/test_portail_e2e_messagerie.py
+++ b/noethysweb/tests/portail/e2e/test_portail_e2e_messagerie.py
@@ -1,0 +1,28 @@
+"""E2E: a family posts a message to a structure (summernote editor)."""
+
+import pytest
+from playwright.sync_api import Page
+
+from core.models import PortailMessage
+from tests.unit.factories import StructureFactory
+
+
+@pytest.mark.django_db
+def test_send_message_flow(auto_login_user, famille_user, live_server, page: Page):
+    user, famille, _ratt = famille_user
+    structure = StructureFactory()
+    page = auto_login_user(user)
+
+    page.goto(f"{live_server.url}/contact/messagerie/{structure.pk}")
+
+    # django-summernote renders a contenteditable .note-editable area.
+    editor = page.locator(".note-editable")
+    editor.click()
+    page.keyboard.type("Bonjour depuis le navigateur")
+
+    page.get_by_role("button", name="Envoyer").click()
+
+    # Redirects back to the conversation; the message is persisted.
+    page.wait_for_url(f"{live_server.url}/contact/messagerie/{structure.pk}")
+    msg = PortailMessage.objects.get(famille=famille, structure=structure)
+    assert "Bonjour depuis le navigateur" in msg.texte

--- a/noethysweb/tests/portail/e2e/test_portail_e2e_navigation.py
+++ b/noethysweb/tests/portail/e2e/test_portail_e2e_navigation.py
@@ -1,0 +1,22 @@
+"""E2E: a logged-in family can reach the main portal pages in a real browser."""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.django_db
+def test_dashboard_and_navigation(auto_login_user, famille_user, live_server, page: Page):
+    user, _famille, _ratt = famille_user
+    page = auto_login_user(user)
+
+    # Dashboard loads.
+    page.goto(f"{live_server.url}/")
+    expect(page).to_have_url(f"{live_server.url}/")
+
+    # The main pages render without error in the browser.
+    for path in ["/renseignements", "/activites", "/documents", "/facturation", "/contact"]:
+        page.goto(f"{live_server.url}{path}")
+        # No Django error page — the debug 500 page has "Traceback" / "Server Error".
+        assert "Server Error" not in page.title()
+        body = page.locator("body").inner_text()
+        assert "Traceback" not in body

--- a/noethysweb/tests/portail/e2e/test_portail_e2e_planning.py
+++ b/noethysweb/tests/portail/e2e/test_portail_e2e_planning.py
@@ -1,0 +1,46 @@
+"""E2E: the reservation planning grid renders in a real browser.
+
+This exercises the heavy Get_data_planning + grille_tableau rendering end-to-end.
+The cell-toggle + Save_grille submission needs the Unite/tariff object graph and
+the grille JS internals — that interaction is left deferred (see TEST_PLAN.md).
+"""
+
+import datetime
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from core.models import PortailPeriode
+from tests.unit.factories import ActiviteFactory, InscriptionFactory
+
+
+@pytest.mark.django_db
+def test_planning_grid_renders(auto_login_user, famille_user, live_server, page: Page):
+    user, famille, ratt = famille_user
+    enfant = ratt[1].individu
+
+    # Clear pending approbations so planning.View.dispatch lets us through.
+    now = datetime.datetime(2024, 1, 1, 12, 0)
+    famille.certification_date = now
+    famille.save(update_fields=["certification_date"])
+    for r in ratt:
+        r.certification_date = now
+        r.save(update_fields=["certification_date"])
+
+    activite = ActiviteFactory(portail_reservations_affichage="TOUJOURS")
+    InscriptionFactory(
+        famille=famille, individu=enfant, activite=activite, internet_reservations=True
+    )
+    periode = PortailPeriode.objects.create(
+        activite=activite, nom="Période E2E",
+        date_debut=datetime.date(2024, 1, 1), date_fin=datetime.date(2030, 12, 31),
+        affichage="TOUJOURS", type_date="TOUTES",
+    )
+
+    page = auto_login_user(user)
+    page.goto(f"{live_server.url}/planning/{enfant.pk}/{activite.pk}/{periode.pk}")
+
+    # The grid table and its save form are rendered.
+    expect(page.locator("#table-grille")).to_have_count(1)
+    expect(page.locator("#form-maj")).to_have_count(1)
+    assert "Traceback" not in page.locator("body").inner_text()

--- a/noethysweb/tests/portail/integration/test_portail_accueil.py
+++ b/noethysweb/tests/portail/integration/test_portail_accueil.py
@@ -1,0 +1,30 @@
+"""Integration tests for the portail dashboard (accueil)."""
+
+import pytest
+
+from core.models import PortailMessage
+
+
+@pytest.mark.django_db
+class TestAccueil:
+    def test_accueil_redirects_when_anonymous(self, client):
+        response = client.get("/", follow=False)
+        assert response.status_code == 302
+        assert "connexion" in response.url
+
+    def test_accueil_renders_for_famille(self, logged_client):
+        response = logged_client.get("/")
+        assert response.status_code == 200
+        assert "portail/accueil.html" in [t.name for t in response.templates]
+
+    def test_accueil_counts_unread_messages(self, logged_client, famille_user, staff_user):
+        _user, famille, _ratt = famille_user
+        from tests.unit.factories import StructureFactory
+
+        structure = StructureFactory()
+        PortailMessage.objects.create(
+            famille=famille, structure=structure, utilisateur=staff_user, texte="Bonjour"
+        )
+        response = logged_client.get("/")
+        assert response.status_code == 200
+        assert response.context["nbre_messages_non_lus"] == 1

--- a/noethysweb/tests/portail/integration/test_portail_activites.py
+++ b/noethysweb/tests/portail/integration/test_portail_activites.py
@@ -1,0 +1,34 @@
+"""Tests for the activities / inscriptions pages."""
+
+import pytest
+from django.urls import reverse
+
+from tests.unit.factories import ActiviteFactory, InscriptionFactory
+
+
+@pytest.mark.django_db
+class TestActivites:
+    def test_list_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_activites"))
+        assert response.status_code == 200
+
+    def test_list_shows_inscription(self, logged_client, famille_user):
+        _user, famille, ratt = famille_user
+        enfant = ratt[1].individu
+        InscriptionFactory(famille=famille, individu=enfant)
+        response = logged_client.get(reverse("portail_activites"))
+        assert response.status_code == 200
+        assert enfant in response.context["liste_individus"]
+
+    def test_inscrire_form_renders(self, logged_client):
+        # An activity must be open to inscription for the page to be meaningful.
+        ActiviteFactory(portail_inscriptions_affichage="TOUJOURS")
+        response = logged_client.get(reverse("portail_inscrire_activite"))
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestCotisations:
+    def test_page_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_cotisations"))
+        assert response.status_code == 200

--- a/noethysweb/tests/portail/integration/test_portail_ajax_authorization.py
+++ b/noethysweb/tests/portail/integration/test_portail_ajax_authorization.py
@@ -1,0 +1,68 @@
+"""Authorization probes for the 16 `@secure_ajax_portail` AJAX endpoints.
+
+The decorator (core/decorators.py) guarantees, before the view runs:
+  - a non-AJAX request           -> 400 Bad Request
+  - an unauthenticated request   -> 403 Forbidden
+  - a non-"famille" user         -> 403 Forbidden
+
+These probes assert the decorator is wired onto every AJAX endpoint, so none of
+them is reachable anonymously, by staff, or via a plain (non-AJAX) request.
+"""
+
+import pytest
+from django.urls import reverse
+
+AJAX = {"HTTP_X_REQUESTED_WITH": "XMLHttpRequest"}
+
+AJAX_ROUTES = [
+    "portail_ajax_facturer",
+    "portail_ajax_get_detail_facture",
+    "portail_ajax_imprimer_facture",
+    "portail_ajax_effectuer_paiement_en_ligne",
+    "portail_ajax_imprimer_recu",
+    "portail_ajax_ajouter_regime_alimentaire",
+    "portail_ajax_ajouter_maladie",
+    "portail_ajax_ajouter_allergie",
+    "portail_ajax_ajouter_dispmed",
+    "portail_ajax_ajouter_medecin",
+    "portail_ajax_ajouter_assureur",
+    "portail_ajax_inscrire_get_form_extra",
+    "portail_ajax_get_activites_par_structure",
+    "portail_ajax_inscrire_valid_form",
+    "ajax_annulation_portail",
+    "portail_ajax_paiement_tpe",
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("route_name", AJAX_ROUTES)
+class TestAjaxEndpointAuthorization:
+    def test_anonymous_forbidden(self, client, organisateur, route_name):
+        response = client.post(reverse(route_name), **AJAX)
+        assert response.status_code == 403
+
+    def test_staff_forbidden(self, client, staff_user, organisateur, route_name):
+        client.force_login(staff_user)
+        response = client.post(reverse(route_name), **AJAX)
+        assert response.status_code == 403
+
+    def test_non_ajax_bad_request(self, logged_client, route_name):
+        # A famille user, but without the AJAX header -> 400 before the view runs.
+        response = logged_client.post(reverse(route_name))
+        assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_famille_passes_decorator(logged_client, famille_user):
+    """A famille AJAX call clears the decorator (creates a RegimeAlimentaire),
+    proving the 403s above are about identity, not a blanket block."""
+    from core.models import RegimeAlimentaire
+
+    response = logged_client.post(
+        reverse("portail_ajax_ajouter_regime_alimentaire"),
+        {"valeur": "Sans gluten"},
+        **AJAX,
+    )
+    # Not blocked by the decorator (would be 400/403); the view handled it.
+    assert response.status_code == 200
+    assert RegimeAlimentaire.objects.filter(nom="Sans gluten").exists()

--- a/noethysweb/tests/portail/integration/test_portail_auth.py
+++ b/noethysweb/tests/portail/integration/test_portail_auth.py
@@ -1,0 +1,40 @@
+"""Tests for portal authentication-adjacent pages (anonymous + logged-in)."""
+
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+class TestAnonymousPages:
+    """Pages reachable without logging in."""
+
+    def test_reset_password_renders(self, client, organisateur):
+        response = client.get(reverse("reset_password"))
+        assert response.status_code == 200
+
+    def test_reset_password_done_renders(self, client, organisateur):
+        response = client.get(reverse("password_reset_done"))
+        assert response.status_code == 200
+
+    def test_inscription_famille_renders(self, client, organisateur):
+        response = client.get(reverse("inscription_famille"))
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestProfil:
+    def test_profil_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_profil"))
+        assert response.status_code == 200
+
+    def test_profil_password_change_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_profil_password_change"))
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestLogout:
+    def test_logout_redirects_to_connexion(self, logged_client):
+        response = logged_client.get(reverse("portail_deconnexion"))
+        assert response.status_code == 302
+        assert "connexion" in response.url

--- a/noethysweb/tests/portail/integration/test_portail_authorization.py
+++ b/noethysweb/tests/portail/integration/test_portail_authorization.py
@@ -1,0 +1,116 @@
+"""Authorization / access-control suite for the family portal.
+
+This is the highest-value portail suite: the portal is the only externally
+exposed interface, so the security guarantees are:
+
+1. Anonymous users are redirected to the login page on every authenticated route.
+2. Staff users (categorie='utilisateur') are denied the family interface.
+3. A family can never read/edit another family's data (cross-family isolation).
+"""
+
+import pytest
+from django.urls import reverse
+
+# Authenticated routes that take no URL arguments.
+SIMPLE_ROUTES = [
+    "portail_accueil",
+    "portail_renseignements",
+    "portail_profil",
+    "portail_cotisations",
+    "portail_documents",
+    "portail_activites",
+    "portail_reservations",
+    "portail_facturation",
+    "portail_reglements",
+    "portail_questionnaires",
+    "portail_verifications",
+    "portail_contact",
+    "portail_mentions",
+    "portail_sondages",
+    "portail_famille_caisse",
+    "portail_famille_caisse_modifier",
+    "portail_famille_questionnaire",
+    "portail_famille_parametres",
+]
+
+# Authenticated routes parameterized by a rattachement id (individual fiches).
+RATTACHEMENT_ROUTES = [
+    "portail_individu_identite",
+    "portail_individu_identite_modifier",
+    "portail_individu_questionnaire",
+    "portail_individu_coords",
+    "portail_individu_regimes_alimentaires",
+    "portail_individu_maladies",
+    "portail_individu_allergies",
+    "portail_individu_dispmed",
+    "portail_individu_traitement",
+    "portail_individu_medecin",
+    "portail_individu_vaccinations",
+    "portail_individu_vaccinations_ajouter",
+    "portail_individu_informations",
+    "portail_individu_assurances",
+    "portail_individu_contacts",
+]
+
+
+@pytest.mark.django_db
+class TestAnonymousRedirected:
+    @pytest.mark.parametrize("route_name", SIMPLE_ROUTES)
+    def test_simple_route_redirects_to_login(self, client, organisateur, route_name):
+        response = client.get(reverse(route_name))
+        assert response.status_code == 302
+        assert "connexion" in response.url
+
+    @pytest.mark.parametrize("route_name", RATTACHEMENT_ROUTES)
+    def test_rattachement_route_redirects_to_login(self, client, famille_user, route_name):
+        _user, _famille, ratt = famille_user
+        url = reverse(route_name, kwargs={"idrattachement": ratt[1].pk})
+        response = client.get(url)
+        assert response.status_code == 302
+        assert "connexion" in response.url
+
+
+@pytest.mark.django_db
+class TestStaffDenied:
+    """A staff user must not be able to use the family portal."""
+
+    def test_staff_redirected_from_accueil(self, client, staff_user, organisateur):
+        client.force_login(staff_user)
+        response = client.get(reverse("portail_accueil"))
+        # Accueil explicitly redirects non-famille users to the staff home.
+        assert response.status_code == 302
+
+    @pytest.mark.parametrize(
+        "route_name",
+        ["portail_renseignements", "portail_facturation", "portail_documents", "portail_contact"],
+    )
+    def test_staff_forbidden_on_portail_pages(self, client, staff_user, organisateur, route_name):
+        client.force_login(staff_user)
+        response = client.get(reverse(route_name))
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+class TestCrossFamilyIsolation:
+    """Family A must not reach Family B's individual fiches."""
+
+    @pytest.mark.parametrize("route_name", RATTACHEMENT_ROUTES)
+    def test_cannot_access_other_family_rattachement(
+        self, client, famille_user, other_famille, route_name
+    ):
+        user_a, _famille_a, _ratt_a = famille_user
+        _user_b, _famille_b, ratt_b = other_famille
+        client.force_login(user_a)
+        # ratt_b[1] is family B's child rattachement.
+        url = reverse(route_name, kwargs={"idrattachement": ratt_b[1].pk})
+        response = client.get(url)
+        assert response.status_code == 403, (
+            f"{route_name} leaked another family's data (got {response.status_code})"
+        )
+
+    def test_can_access_own_rattachement(self, client, famille_user):
+        user_a, _famille_a, ratt_a = famille_user
+        client.force_login(user_a)
+        url = reverse("portail_individu_identite", kwargs={"idrattachement": ratt_a[1].pk})
+        response = client.get(url)
+        assert response.status_code == 200

--- a/noethysweb/tests/portail/integration/test_portail_billing.py
+++ b/noethysweb/tests/portail/integration/test_portail_billing.py
@@ -1,0 +1,46 @@
+"""Tests for the billing pages (facturation, reglements, payment-return pages).
+
+Payment gateway internals (Payzen/PayFip/HelloAsso/Stripe/TPE endpoints and IPN
+callbacks) are intentionally out of scope — see TEST_PLAN.md.
+"""
+
+import pytest
+from django.urls import reverse
+
+from tests.unit.factories import FactureFactory
+
+
+@pytest.mark.django_db
+class TestFacturation:
+    def test_page_renders_empty(self, logged_client):
+        response = logged_client.get(reverse("portail_facturation"))
+        assert response.status_code == 200
+
+    def test_page_renders_with_facture(self, logged_client, famille_user):
+        _user, famille, _ratt = famille_user
+        FactureFactory(famille=famille, total=120, solde_actuel=120)
+        response = logged_client.get(reverse("portail_facturation"))
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestReglements:
+    def test_page_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_reglements"))
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "route_name",
+    [
+        "retour_payzen_cancel",
+        "retour_payzen_error",
+        "retour_payzen_refused",
+        "retour_payzen_success",
+    ],
+)
+def test_payment_return_pages_render(logged_client, route_name):
+    """The Payzen return *pages* are plain template renders (no gateway call)."""
+    response = logged_client.get(reverse(route_name))
+    assert response.status_code == 200

--- a/noethysweb/tests/portail/integration/test_portail_contact.py
+++ b/noethysweb/tests/portail/integration/test_portail_contact.py
@@ -1,0 +1,52 @@
+"""Tests for the contact hub, per-structure conversation and messagerie."""
+
+import pytest
+from django.urls import reverse
+
+from core.models import PortailMessage
+from tests.unit.factories import PortailMessageFactory, StructureFactory
+
+
+@pytest.mark.django_db
+class TestContact:
+    def test_hub_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_contact"))
+        assert response.status_code == 200
+
+    def test_conversation_renders_and_marks_read(self, logged_client, famille_user, staff_user):
+        _user, famille, _ratt = famille_user
+        structure = StructureFactory()
+        msg = PortailMessageFactory(
+            famille=famille, structure=structure, utilisateur=staff_user
+        )
+        assert msg.date_lecture is None
+
+        url = reverse("portail_contact_conversation", kwargs={"idstructure": structure.pk})
+        response = logged_client.get(url)
+        assert response.status_code == 200
+        # Opening the conversation marks the incoming message as read.
+        msg.refresh_from_db()
+        assert msg.date_lecture is not None
+
+
+@pytest.mark.django_db
+class TestMessagerie:
+    def test_form_renders(self, logged_client):
+        structure = StructureFactory()
+        url = reverse("portail_messagerie", kwargs={"idstructure": structure.pk})
+        response = logged_client.get(url)
+        assert response.status_code == 200
+
+    def test_post_creates_message(self, logged_client, famille_user):
+        _user, famille, _ratt = famille_user
+        structure = StructureFactory()
+        url = reverse("portail_messagerie", kwargs={"idstructure": structure.pk})
+        response = logged_client.post(
+            url,
+            {"famille": famille.pk, "structure": structure.pk, "texte": "Bonjour la structure"},
+        )
+        assert response.status_code == 302
+        msg = PortailMessage.objects.get(famille=famille, structure=structure)
+        assert msg.texte == "Bonjour la structure"
+        # A family-sent message has no staff utilisateur.
+        assert msg.utilisateur is None

--- a/noethysweb/tests/portail/integration/test_portail_documents.py
+++ b/noethysweb/tests/portail/integration/test_portail_documents.py
@@ -1,0 +1,94 @@
+"""Tests for the documents page, upload (transmettre) and piece deletion.
+
+Includes security probes for `supprimer_piece`, which is a plain function view
+with no authentication or ownership checks (see TEST_PLAN.md).
+"""
+
+import pytest
+from django.urls import reverse
+
+from core.models import Piece
+from tests.unit.factories import PieceFactory
+
+
+@pytest.mark.django_db
+class TestDocumentsPage:
+    def test_page_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_documents"))
+        assert response.status_code == 200
+
+    def test_lists_family_pieces(self, logged_client, famille_user):
+        _user, famille, _ratt = famille_user
+        PieceFactory(famille=famille, titre="Justificatif")
+        response = logged_client.get(reverse("portail_documents"))
+        assert response.status_code == 200
+        assert any(p.titre == "Justificatif" for p in response.context["liste_pieces"])
+
+
+@pytest.mark.django_db
+class TestTransmettrePiece:
+    def test_upload_form_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_transmettre_piece"))
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestSupprimerPiece:
+    @pytest.mark.xfail(
+        reason="BUG: supprimer_piece GET renders 'core/confirmation_suppression.html' "
+        "which does not exist -> TemplateDoesNotExist (500). See TEST_PLAN.md.",
+        strict=True,
+    )
+    def test_confirmation_page_renders_for_owner(self, logged_client, famille_user):
+        _user, famille, _ratt = famille_user
+        piece = PieceFactory(famille=famille)
+        response = logged_client.get(reverse("supprimer_piece", kwargs={"pk": piece.pk}))
+        assert response.status_code == 200
+
+    def test_owner_can_delete_own_piece(self, logged_client, famille_user):
+        _user, famille, _ratt = famille_user
+        piece = PieceFactory(famille=famille)
+        response = logged_client.post(reverse("supprimer_piece", kwargs={"pk": piece.pk}))
+        assert response.status_code == 302
+        assert not Piece.objects.filter(pk=piece.pk).exists()
+
+    @pytest.mark.xfail(
+        reason="BUG: documents.supprimer_piece is a plain function view with no "
+        "login/ownership check — an anonymous user can delete any Piece by pk. "
+        "See TEST_PLAN.md.",
+        strict=True,
+    )
+    def test_anonymous_cannot_delete_piece(self, client, famille_user):
+        _user, famille, _ratt = famille_user
+        piece = PieceFactory(famille=famille)
+        client.post(reverse("supprimer_piece", kwargs={"pk": piece.pk}))
+        assert Piece.objects.filter(pk=piece.pk).exists()
+
+    @pytest.mark.xfail(
+        reason="BUG: documents.supprimer_piece has no ownership check — family A can "
+        "delete family B's Piece by pk. See TEST_PLAN.md.",
+        strict=True,
+    )
+    def test_cannot_delete_other_family_piece(self, logged_client, other_famille):
+        _user_b, famille_b, _ratt_b = other_famille
+        piece = PieceFactory(famille=famille_b)
+        logged_client.post(reverse("supprimer_piece", kwargs={"pk": piece.pk}))
+        assert Piece.objects.filter(pk=piece.pk).exists()
+
+
+@pytest.mark.django_db
+class TestModifierPiece:
+    @pytest.mark.xfail(
+        reason="BUG: transmettre_piece.Modifier.get_queryset filters only by pk (no "
+        "famille) despite its 'sécurité' comment — family A can open/modify family B's "
+        "Piece via /documents/modifier/<pk>/. See TEST_PLAN.md.",
+        strict=True,
+    )
+    def test_cannot_open_other_family_piece(self, logged_client, other_famille):
+        _user_b, famille_b, _ratt_b = other_famille
+        piece = PieceFactory(famille=famille_b)
+        response = logged_client.get(
+            reverse("portail_documents_modifier", kwargs={"pk": piece.pk})
+        )
+        # Secure behaviour would deny (403/404); the bug returns the edit form (200).
+        assert response.status_code != 200

--- a/noethysweb/tests/portail/integration/test_portail_individu_crud.py
+++ b/noethysweb/tests/portail/integration/test_portail_individu_crud.py
@@ -1,0 +1,56 @@
+"""Functional CRUD tests for an individual sub-resource (emergency contacts).
+
+Covers add (POST creates) and delete (POST removes) through the Onglet-based
+CRUD views, which also enforce the cross-family ownership check.
+"""
+
+import pytest
+from django.db.models.fields.files import FieldFile
+from django.urls import reverse
+
+from core.models import ContactUrgence
+
+
+def build_form_data(form, **overrides):
+    data = {}
+    for name in form.fields:
+        val = form.initial.get(name, form.fields[name].initial)
+        if val is None or isinstance(val, FieldFile) or hasattr(val, "read"):
+            continue
+        data[name] = val.isoformat() if hasattr(val, "isoformat") else val
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.django_db
+class TestContactsCrud:
+    def test_add_contact(self, logged_client, famille_user):
+        _user, famille, ratt = famille_user
+        enfant = ratt[1].individu
+        url = reverse("portail_individu_contacts_ajouter", kwargs={"idrattachement": ratt[1].pk})
+
+        form = logged_client.get(url).context["form"]
+        data = build_form_data(
+            form, nom="Mamie", prenom="Jeanne", lien="Grand-mère",
+            famille=famille.pk, individu=enfant.pk,
+        )
+        response = logged_client.post(url, data)
+
+        assert response.status_code == 302
+        assert ContactUrgence.objects.filter(
+            individu=enfant, famille=famille, nom="Mamie"
+        ).exists()
+
+    def test_delete_contact(self, logged_client, famille_user):
+        _user, famille, ratt = famille_user
+        enfant = ratt[1].individu
+        contact = ContactUrgence.objects.create(
+            individu=enfant, famille=famille, nom="ASupprimer", prenom="Test"
+        )
+        url = reverse(
+            "portail_individu_contacts_supprimer",
+            kwargs={"idrattachement": ratt[1].pk, "idcontact": contact.pk},
+        )
+        response = logged_client.post(url)
+        assert response.status_code == 302
+        assert not ContactUrgence.objects.filter(pk=contact.pk).exists()

--- a/noethysweb/tests/portail/integration/test_portail_membres.py
+++ b/noethysweb/tests/portail/integration/test_portail_membres.py
@@ -1,0 +1,39 @@
+"""Tests for adding family members (child / parent) from the portal."""
+
+import pytest
+from django.urls import reverse
+
+from core.models import Individu, Rattachement
+
+
+@pytest.mark.django_db
+class TestAjoutEnfant:
+    def test_form_renders(self, logged_client):
+        response = logged_client.get(reverse("famille_individu"))
+        assert response.status_code == 200
+        assert "form" in response.context
+
+    def test_post_creates_child_and_rattachement(self, logged_client, famille_user):
+        _user, famille, _ratt = famille_user
+        before = Rattachement.objects.filter(famille=famille).count()
+
+        response = logged_client.post(
+            reverse("famille_individu"),
+            {
+                "civilite": 1,
+                "prenom": "Nouvel",
+                "nom": "Enfant",
+                "date_naiss": "2016-05-05",
+                "copier_adresse_parent": "on",
+            },
+        )
+        assert response.status_code == 302
+        assert Rattachement.objects.filter(famille=famille).count() == before + 1
+        assert Individu.objects.filter(prenom="Nouvel", nom="Enfant").exists()
+
+
+@pytest.mark.django_db
+class TestAjoutParent:
+    def test_form_renders(self, logged_client):
+        response = logged_client.get(reverse("famille_parent"))
+        assert response.status_code == 200

--- a/noethysweb/tests/portail/integration/test_portail_misc.py
+++ b/noethysweb/tests/portail/integration/test_portail_misc.py
@@ -1,0 +1,31 @@
+"""Tests for miscellaneous portal pages (mentions, email unsubscribe)."""
+
+import pytest
+from django.urls import reverse
+
+from core.models import Album
+
+
+@pytest.mark.django_db
+class TestMentions:
+    def test_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_mentions"))
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestAlbum:
+    def test_renders_for_valid_code(self, logged_client):
+        album = Album.objects.create(titre="Sortie 2024", code="album-test-code")
+        response = logged_client.get(reverse("portail_album", kwargs={"code": album.code}))
+        assert response.status_code == 200
+        assert response.context["album"].pk == album.pk
+
+
+@pytest.mark.django_db
+class TestDesinscription:
+    def test_renders_with_invalid_token(self, client):
+        """The unsubscribe page is public (csrf-exempt, GET) and renders even
+        for an unrecognised token."""
+        response = client.get(reverse("desinscription", kwargs={"valeur": "invalid-token"}))
+        assert response.status_code == 200

--- a/noethysweb/tests/portail/integration/test_portail_pages.py
+++ b/noethysweb/tests/portail/integration/test_portail_pages.py
@@ -1,0 +1,38 @@
+"""Render-smoke tests for the simple (no-argument) portail pages.
+
+Every page is fetched as a logged-in family and must return 200. These catch
+template/context regressions across the whole portal in one cheap sweep.
+"""
+
+import pytest
+from django.urls import reverse
+
+RENDER_ROUTES = [
+    "portail_accueil",
+    "portail_renseignements",
+    "portail_profil",
+    "portail_documents",
+    "portail_activites",
+    "portail_reservations",
+    "portail_facturation",
+    "portail_reglements",
+    "portail_questionnaires",
+    "portail_verifications",
+    "portail_contact",
+    "portail_mentions",
+    "portail_sondages",
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("route_name", RENDER_ROUTES)
+def test_page_renders_200(logged_client, route_name):
+    response = logged_client.get(reverse(route_name))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_cotisations_page_renders(logged_client):
+    # cotisations_afficher_page defaults to False; the page itself still loads.
+    response = logged_client.get(reverse("portail_cotisations"))
+    assert response.status_code == 200

--- a/noethysweb/tests/portail/integration/test_portail_renseignements.py
+++ b/noethysweb/tests/portail/integration/test_portail_renseignements.py
@@ -1,0 +1,123 @@
+"""Render-smoke tests for the renseignements fiches (individual + family).
+
+Each individual fiche is parameterized by the family's child rattachement.
+"""
+
+import pytest
+from django.urls import reverse
+
+# Individual fiche consultation pages (take idrattachement).
+INDIVIDU_CONSULTER_ROUTES = [
+    "portail_individu_identite",
+    "portail_individu_questionnaire",
+    "portail_individu_coords",
+    "portail_individu_regimes_alimentaires",
+    "portail_individu_maladies",
+    "portail_individu_allergies",
+    "portail_individu_dispmed",
+    "portail_individu_traitement",
+    "portail_individu_medecin",
+    "portail_individu_vaccinations",
+    "portail_individu_informations",
+    "portail_individu_assurances",
+    "portail_individu_contacts",
+]
+
+# Individual fiche edit/add pages (take idrattachement).
+INDIVIDU_FORM_ROUTES = [
+    "portail_individu_identite_modifier",
+    "portail_individu_coords_modifier",
+    "portail_individu_regimes_alimentaires_modifier",
+    "portail_individu_maladies_modifier",
+    "portail_individu_allergies_modifier",
+    "portail_individu_dispmed_modifier",
+    "portail_individu_medecin_modifier",
+    "portail_individu_vaccinations_ajouter",
+    "portail_individu_informations_ajouter",
+    "portail_individu_assurances_ajouter",
+    "portail_individu_contacts_ajouter",
+]
+
+FAMILLE_ROUTES = [
+    "portail_famille_caisse",
+    "portail_famille_caisse_modifier",
+    "portail_famille_questionnaire",
+    "portail_famille_parametres",
+]
+
+
+def form_post_data(form):
+    """Build a POST payload from a bound form's initial values.
+
+    Skips file/image fields (empty FieldFiles break multipart encoding) and
+    ISO-formats dates so the fr-locale DATE_INPUT_FORMATS accept them.
+    """
+    from django.db.models.fields.files import FieldFile
+
+    data = {}
+    for name in form.fields:
+        val = form.initial.get(name, form.fields[name].initial)
+        if val is None:
+            continue
+        if isinstance(val, FieldFile) or hasattr(val, "read"):  # file field
+            continue
+        if hasattr(val, "isoformat"):  # date / datetime
+            val = val.isoformat()
+        data[name] = val
+    return data
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("route_name", INDIVIDU_CONSULTER_ROUTES)
+def test_individu_consulter_renders(logged_client, famille_user, route_name):
+    _user, _famille, ratt = famille_user
+    url = reverse(route_name, kwargs={"idrattachement": ratt[1].pk})
+    response = logged_client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("route_name", INDIVIDU_FORM_ROUTES)
+def test_individu_form_renders(logged_client, famille_user, route_name):
+    _user, _famille, ratt = famille_user
+    url = reverse(route_name, kwargs={"idrattachement": ratt[1].pk})
+    response = logged_client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("route_name", FAMILLE_ROUTES)
+def test_famille_page_renders(logged_client, route_name):
+    response = logged_client.get(reverse(route_name))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_identite_modifier_saves_change(logged_client, famille_user):
+    """Editing identity (validation_auto=True) persists the change to the Individu."""
+    from core.models import Individu
+
+    _user, _famille, ratt = famille_user
+    enfant = ratt[1].individu
+    url = reverse("portail_individu_identite_modifier", kwargs={"idrattachement": ratt[1].pk})
+    response = logged_client.get(url)
+    assert response.status_code == 200
+
+    data = form_post_data(response.context["form"])
+    data["nom"] = "NouveauNom"
+
+    post = logged_client.post(url, data)
+    assert post.status_code == 302
+    assert Individu.objects.get(pk=enfant.pk).nom == "NouveauNom"
+
+
+@pytest.mark.xfail(
+    reason="BUG: utils_onglets.py:27 has the 'famille_parametres' onglet commented out, "
+    "so Get_onglet returns None and famille_parametres.Modifier.get_context_data "
+    "crashes on .validation_auto (500). See TEST_PLAN.md.",
+    strict=True,
+)
+@pytest.mark.django_db
+def test_famille_parametres_modifier_renders(logged_client):
+    response = logged_client.get(reverse("portail_famille_parametres_modifier"))
+    assert response.status_code == 200

--- a/noethysweb/tests/portail/integration/test_portail_reservations.py
+++ b/noethysweb/tests/portail/integration/test_portail_reservations.py
@@ -1,0 +1,91 @@
+"""Tests for the reservations list and the planning (booking grid) page.
+
+The planning grid POST (Save_grille) needs a full grille JSON payload and is
+exercised by the wizard/E2E layer; here we cover the page render and the
+ownership/authorization logic in planning.View.test_func.
+"""
+
+import datetime
+
+import pytest
+from django.urls import reverse
+
+from core.models import PortailPeriode
+from tests.unit.factories import ActiviteFactory, InscriptionFactory
+
+
+def make_periode(activite):
+    return PortailPeriode.objects.create(
+        activite=activite,
+        nom="Période test",
+        date_debut=datetime.date(2024, 1, 1),
+        date_fin=datetime.date(2030, 12, 31),
+        affichage="TOUJOURS",
+        type_date="TOUTES",
+    )
+
+
+def certify(famille, rattachements):
+    """Clear all pending approbations so planning.View.dispatch lets the request
+    through to test_func (otherwise it redirects to renseignements)."""
+    now = datetime.datetime(2024, 1, 1, 12, 0)
+    famille.certification_date = now
+    famille.save(update_fields=["certification_date"])
+    for ratt in rattachements:
+        ratt.certification_date = now
+        ratt.save(update_fields=["certification_date"])
+
+
+@pytest.mark.django_db
+class TestReservationsList:
+    def test_page_renders(self, logged_client):
+        response = logged_client.get(reverse("portail_reservations"))
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestPlanning:
+    def _url(self, individu, activite, periode):
+        return reverse(
+            "portail_planning",
+            kwargs={
+                "idindividu": individu.pk,
+                "idactivite": activite.pk,
+                "idperiode": periode.pk,
+            },
+        )
+
+    def test_forbidden_without_inscription(self, logged_client, famille_user):
+        _user, famille, ratt = famille_user
+        certify(famille, ratt)
+        activite = ActiviteFactory(portail_reservations_affichage="TOUJOURS")
+        periode = make_periode(activite)
+        # No inscription links the child to this activity -> test_func fails.
+        response = logged_client.get(self._url(ratt[1].individu, activite, periode))
+        assert response.status_code == 403
+
+    def test_renders_with_inscription(self, logged_client, famille_user):
+        _user, famille, ratt = famille_user
+        certify(famille, ratt)
+        enfant = ratt[1].individu
+        activite = ActiviteFactory(portail_reservations_affichage="TOUJOURS")
+        InscriptionFactory(
+            famille=famille, individu=enfant, activite=activite, internet_reservations=True
+        )
+        periode = make_periode(activite)
+        response = logged_client.get(self._url(enfant, activite, periode))
+        assert response.status_code == 200
+
+    def test_cross_family_individu_forbidden(self, logged_client, famille_user, other_famille):
+        _ua, famille_a, ratt_a = famille_user
+        certify(famille_a, ratt_a)
+        _ub, _famille_b, ratt_b = other_famille
+        activite = ActiviteFactory(portail_reservations_affichage="TOUJOURS")
+        # Inscription belongs to family A's child; we request family B's child id.
+        InscriptionFactory(
+            famille=famille_a, individu=ratt_a[1].individu, activite=activite,
+            internet_reservations=True,
+        )
+        periode = make_periode(activite)
+        response = logged_client.get(self._url(ratt_b[1].individu, activite, periode))
+        assert response.status_code == 403

--- a/noethysweb/tests/portail/integration/test_portail_surveys.py
+++ b/noethysweb/tests/portail/integration/test_portail_surveys.py
@@ -1,0 +1,59 @@
+"""Tests for the survey (sondage) flow: intro -> questions -> conclusion."""
+
+import pytest
+from django.urls import reverse
+
+from core.models import (
+    SondagePage,
+    SondageQuestion,
+    SondageRepondant,
+    SondageReponse,
+)
+from tests.unit.factories import SondageFactory
+
+
+@pytest.fixture
+def sondage_famille(db):
+    """A family survey with one page and one free-text question."""
+    sondage = SondageFactory(public="famille", conclusion="Merci !")
+    page = SondagePage.objects.create(sondage=sondage, titre="Page 1", ordre=1)
+    question = SondageQuestion.objects.create(
+        page=page, label="Votre avis ?", controle="ligne_texte", ordre=1
+    )
+    return sondage, page, question
+
+
+@pytest.mark.django_db
+class TestSondageFlow:
+    def test_introduction_renders(self, logged_client, sondage_famille):
+        sondage, _page, _q = sondage_famille
+        url = reverse("portail_sondage", kwargs={"code": sondage.code})
+        response = logged_client.get(url)
+        assert response.status_code == 200
+        assert response.context["sondage"].pk == sondage.pk
+
+    def test_questions_render(self, logged_client, sondage_famille):
+        sondage, _page, _q = sondage_famille
+        url = reverse("portail_sondage_questions", kwargs={"code": sondage.code})
+        response = logged_client.get(url)
+        assert response.status_code == 200
+        assert len(response.context["pages"]) == 1
+
+    def test_conclusion_renders(self, logged_client, sondage_famille):
+        sondage, _page, _q = sondage_famille
+        url = reverse("portail_sondage_conclusion", kwargs={"code": sondage.code})
+        response = logged_client.get(url)
+        assert response.status_code == 200
+
+    def test_post_answers_creates_repondant_and_response(
+        self, logged_client, famille_user, sondage_famille
+    ):
+        _user, famille, _ratt = famille_user
+        sondage, _page, question = sondage_famille
+        url = reverse("portail_sondage_questions", kwargs={"code": sondage.code})
+        response = logged_client.post(url, {"question_%d" % question.pk: "Très bien"})
+        assert response.status_code == 302
+        repondant = SondageRepondant.objects.get(sondage=sondage, famille=famille)
+        assert SondageReponse.objects.filter(
+            repondant=repondant, question=question, reponse="Très bien"
+        ).exists()

--- a/noethysweb/tests/portail/integration/test_portail_wizard.py
+++ b/noethysweb/tests/portail/integration/test_portail_wizard.py
@@ -1,0 +1,64 @@
+"""Tests for the activity-inscription AJAX wizard steps.
+
+Covers the cascading endpoints used by the inscription form:
+  Get_activites_par_structure -> Get_form_extra -> Valid_form
+"""
+
+import pytest
+from django.urls import reverse
+
+from tests.unit.factories import ActiviteFactory, GroupeFactory, StructureFactory
+
+AJAX = {"HTTP_X_REQUESTED_WITH": "XMLHttpRequest"}
+
+
+@pytest.mark.django_db
+class TestGetActivitesParStructure:
+    def test_returns_activities_with_groups(self, logged_client):
+        structure = StructureFactory()
+        activite = ActiviteFactory(structure=structure, visible=True)
+        GroupeFactory(activite=activite, nom="Groupe A")
+
+        response = logged_client.post(
+            reverse("portail_ajax_get_activites_par_structure"),
+            {"structure_id": structure.pk},
+            **AJAX,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["activites"]) == 1
+        assert data["activites"][0]["nom"] == activite.nom
+        assert data["activites"][0]["groupes"][0]["nom"] == "Groupe A"
+
+
+@pytest.mark.django_db
+class TestGetFormExtra:
+    def test_missing_params_returns_prompt(self, logged_client):
+        response = logged_client.post(
+            reverse("portail_ajax_inscrire_get_form_extra"), {}, **AJAX
+        )
+        assert response.status_code == 200
+        assert "Veuillez sélectionner" in response.json()["form_html"]
+
+    def test_returns_form_html(self, logged_client, famille_user):
+        _user, _famille, ratt = famille_user
+        enfant = ratt[1].individu
+        activite = ActiviteFactory()
+        response = logged_client.post(
+            reverse("portail_ajax_inscrire_get_form_extra"),
+            {"individu": enfant.pk, "activite": activite.pk},
+            **AJAX,
+        )
+        assert response.status_code == 200
+        assert "form_html" in response.json()
+
+
+@pytest.mark.django_db
+class TestValidForm:
+    def test_invalid_submission_returns_400(self, logged_client):
+        # Empty payload -> the main form is invalid -> 400 with an error message.
+        response = logged_client.post(
+            reverse("portail_ajax_inscrire_valid_form"), {}, **AJAX
+        )
+        assert response.status_code == 400
+        assert "erreur" in response.json()

--- a/noethysweb/tests/portail/test_signin.py
+++ b/noethysweb/tests/portail/test_signin.py
@@ -1,7 +1,6 @@
-import re
 
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page
 
 from core.models import Utilisateur, AdresseMail, Organisateur
 

--- a/noethysweb/tests/unit/factories.py
+++ b/noethysweb/tests/unit/factories.py
@@ -1,3 +1,5 @@
+import datetime
+
 import factory
 from django.contrib.auth.hashers import make_password
 from factory.django import DjangoModelFactory
@@ -39,3 +41,174 @@ class UtilisateurFactory(DjangoModelFactory):
     categorie = "utilisateur"
     is_staff = True
     is_superuser = True
+
+
+class FamilleUtilisateurFactory(DjangoModelFactory):
+    """Creates a portail (family) user with password 'testpassword'."""
+
+    class Meta:
+        model = "core.Utilisateur"
+
+    username = factory.Sequence(lambda n: f"famille{n}")
+    password = factory.LazyFunction(lambda: make_password("testpassword"))
+    email = factory.Sequence(lambda n: f"famille{n}@test.org")
+    categorie = "famille"
+    is_staff = False
+    is_superuser = False
+
+
+class FamilleFactory(DjangoModelFactory):
+    """Creates a Famille. Pass utilisateur=... to link it to a portail user."""
+
+    class Meta:
+        model = "core.Famille"
+
+    nom = factory.Sequence(lambda n: f"Famille {n}")
+
+
+class IndividuFactory(DjangoModelFactory):
+    """Creates an Individu (a person — parent, child or contact)."""
+
+    class Meta:
+        model = "core.Individu"
+
+    nom = factory.Sequence(lambda n: f"Nom{n}")
+    prenom = factory.Sequence(lambda n: f"Prenom{n}")
+    date_naiss = datetime.date(2015, 1, 1)
+
+
+class RattachementFactory(DjangoModelFactory):
+    """Links an Individu to a Famille. categorie: 1=adulte, 2=enfant, 3=contact."""
+
+    class Meta:
+        model = "core.Rattachement"
+
+    individu = factory.SubFactory(IndividuFactory)
+    famille = factory.SubFactory(FamilleFactory)
+    categorie = 2  # CATEGORIE_RATTACHEMENT_ENFANT
+    titulaire = False
+
+
+class ActiviteFactory(DjangoModelFactory):
+    class Meta:
+        model = "core.Activite"
+
+    nom = factory.Sequence(lambda n: f"Activite {n}")
+    abrege = factory.Sequence(lambda n: f"Act{n}")
+    structure = factory.SubFactory(StructureFactory)
+    visible = True
+    portail_inscriptions_affichage = "TOUJOURS"
+    portail_reservations_affichage = "TOUJOURS"
+
+
+class GroupeFactory(DjangoModelFactory):
+    class Meta:
+        model = "core.Groupe"
+
+    activite = factory.SubFactory(ActiviteFactory)
+    nom = factory.Sequence(lambda n: f"Groupe {n}")
+    ordre = factory.Sequence(lambda n: n + 1)
+
+
+class InscriptionFactory(DjangoModelFactory):
+    class Meta:
+        model = "core.Inscription"
+
+    individu = factory.SubFactory(IndividuFactory)
+    famille = factory.SubFactory(FamilleFactory)
+    activite = factory.SubFactory(ActiviteFactory)
+    groupe = factory.SubFactory(
+        GroupeFactory, activite=factory.SelfAttribute("..activite")
+    )
+    date_debut = datetime.date(2020, 1, 1)
+    statut = "ok"
+
+
+class TypePieceFactory(DjangoModelFactory):
+    class Meta:
+        model = "core.TypePiece"
+
+    nom = factory.Sequence(lambda n: f"Type piece {n}")
+
+
+class PieceFactory(DjangoModelFactory):
+    class Meta:
+        model = "core.Piece"
+
+    type_piece = factory.SubFactory(TypePieceFactory)
+    famille = factory.SubFactory(FamilleFactory)
+    titre = factory.Sequence(lambda n: f"Piece {n}")
+
+
+class PortailMessageFactory(DjangoModelFactory):
+    """A message in the family <-> structure conversation.
+
+    Pass utilisateur=<staff user> to simulate a staff-sent (incoming) message;
+    leave it None for a family-sent message.
+    """
+
+    class Meta:
+        model = "core.PortailMessage"
+
+    famille = factory.SubFactory(FamilleFactory)
+    structure = factory.SubFactory(StructureFactory)
+    texte = factory.Sequence(lambda n: f"Message {n}")
+
+
+class SondageFactory(DjangoModelFactory):
+    class Meta:
+        model = "core.Sondage"
+
+    titre = factory.Sequence(lambda n: f"Sondage {n}")
+    public = "famille"
+
+
+class FactureFactory(DjangoModelFactory):
+    class Meta:
+        model = "core.Facture"
+
+    numero = factory.Sequence(lambda n: 1000 + n)
+    famille = factory.SubFactory(FamilleFactory)
+    date_edition = datetime.date(2024, 1, 1)
+    date_debut = datetime.date(2024, 1, 1)
+    date_fin = datetime.date(2024, 12, 31)
+    total = 100
+    solde_actuel = 100
+
+
+def create_famille_user(username="famille", password="testpassword"):
+    """Create a portail user linked to a Famille and return (utilisateur, famille).
+
+    A famille user must have a linked Famille or portail pages raise — see
+    portail/views/base.py::CustomView.get_context_data.
+    """
+    user = FamilleUtilisateurFactory(
+        username=username, password=make_password(password)
+    )
+    famille = FamilleFactory(utilisateur=user)
+    return user, famille
+
+
+def create_famille_complete(username="famille", password="testpassword", avec_enfant=True):
+    """Create a fully usable portail family and return (user, famille, rattachements).
+
+    Builds the Famille + a titulaire adult Individu (set as `allocataire`) and,
+    by default, one child. Most portail pages iterate on rattachements, so an
+    empty famille is not enough to exercise them.
+    """
+    user, famille = create_famille_user(username=username, password=password)
+
+    titulaire = IndividuFactory(nom="Titulaire", prenom="Adulte", date_naiss=datetime.date(1985, 1, 1))
+    rattachements = [
+        RattachementFactory(individu=titulaire, famille=famille, categorie=1, titulaire=True)
+    ]
+    famille.allocataire = titulaire
+    famille.save()
+
+    if avec_enfant:
+        enfant = IndividuFactory(nom="Enfant", prenom="Premier")
+        rattachements.append(
+            RattachementFactory(individu=enfant, famille=famille, categorie=2)
+        )
+
+    return user, famille, rattachements


### PR DESCRIPTION
## Summary

Adds an integration + E2E test suite for the **family portal** (`portail/`), plus a `tests/portail/TEST_PLAN.md` that tracks known bugs as strict `xfail`s. **Tests only — no code fixes in this PR.** Draft for review.

## Security findings (documented, not fixed) je suis même pas sur de leur états, ya moyen c'est du pipau, j'ai pas réussi a éxtraire des infos du # 4

| # | Area | Impact | Status |
|---|------|--------|--------|
| 4 | `portail_documents_modifier` — `Modifier.get_queryset()` filters by `pk` only, no `famille` | **Low.** Cross-family access returns the edit form (HTTP 200), but it leaks **metadata only** (title/dates/individu); the `FileInput` widget renders no link to the file, so document content is not exposed via this route. | `xfail(strict)` |
| 2/3 | `supprimer_piece` (`documents.py:75`) — plain function view, no `@login_required`, no ownership check | **Medium.** Anonymous user can delete any `Piece` by pk; any family can delete another family's pieces. GET also 500s (missing template). | `xfail(strict)` |
