### PR TITLE
Add permission-checked document serving

### DIFF
--- a/noethysweb/core/views/media.py
+++ b/noethysweb/core/views/media.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+import mimetypes
+import os
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+from django.http import FileResponse, Http404
+from django.shortcuts import get_object_or_404, redirect
+from django.views import View
+
+from core.models import (
+    Activite, Assurance, ComptaOperation, Information, Inscription,
+    Piece, Photo, PortailDocument, Quotient, Rattachement,
+)
+
+
+class BaseDocumentView(View):
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return redirect("portail_connexion")
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_object(self, pk):
+        raise NotImplementedError
+
+    def check_permission(self, user, obj):
+        raise NotImplementedError
+
+    def get_file_field(self, obj):
+        return obj.document
+
+    def get(self, request, pk):
+        obj = self.get_object(pk)
+        if not self.check_permission(request.user, obj):
+            raise PermissionDenied
+        field = self.get_file_field(obj)
+        if not field:
+            raise Http404
+        path = os.path.join(settings.MEDIA_ROOT, field.name)
+        if not os.path.exists(path):
+            raise Http404
+        content_type, _ = mimetypes.guess_type(path)
+        response = FileResponse(
+            open(path, "rb"),
+            content_type=content_type or "application/octet-stream",
+        )
+        response["Content-Disposition"] = f'inline; filename="{os.path.basename(field.name)}"'
+        return response
+
+    def _accessible_activites(self, user):
+        return Activite.objects.filter(structure__in=user.structures.all())
+
+    def _famille_accessible(self, famille, user):
+        return Inscription.objects.filter(
+            famille=famille,
+            activite__in=self._accessible_activites(user),
+        ).exists()
+
+    def _individu_accessible(self, individu, user):
+        famille_ids = Rattachement.objects.filter(individu=individu).values_list("famille_id", flat=True)
+        return Inscription.objects.filter(
+            famille_id__in=famille_ids,
+            activite__in=self._accessible_activites(user),
+        ).exists()
+
+
+class PieceDocumentView(BaseDocumentView):
+    def get_object(self, pk):
+        return get_object_or_404(Piece.objects.select_related("famille", "individu"), pk=pk)
+
+    def check_permission(self, user, obj):
+        if user.categorie == "utilisateur":
+            if obj.famille:
+                return self._famille_accessible(obj.famille, user)
+            if obj.individu:
+                return self._individu_accessible(obj.individu, user)
+            return False
+        if user.categorie == "famille":
+            famille = getattr(user, "famille", None)
+            if not famille:
+                return False
+            if obj.famille == famille:
+                return True
+            if obj.individu:
+                return Rattachement.objects.filter(individu=obj.individu, famille=famille).exists()
+            return False
+        return False
+
+
+class QuotientDocumentView(BaseDocumentView):
+    def get_object(self, pk):
+        return get_object_or_404(Quotient.objects.select_related("famille"), pk=pk)
+
+    def check_permission(self, user, obj):
+        if user.categorie == "utilisateur":
+            return self._famille_accessible(obj.famille, user)
+        if user.categorie == "famille":
+            famille = getattr(user, "famille", None)
+            return famille is not None and obj.famille == famille
+        return False
+
+
+class AssuranceDocumentView(BaseDocumentView):
+    def get_object(self, pk):
+        return get_object_or_404(Assurance.objects.select_related("individu", "famille"), pk=pk)
+
+    def check_permission(self, user, obj):
+        if user.categorie == "utilisateur":
+            return self._individu_accessible(obj.individu, user)
+        if user.categorie == "famille":
+            famille = getattr(user, "famille", None)
+            return famille is not None and obj.famille == famille
+        return False
+
+
+class InformationDocumentView(BaseDocumentView):
+    def get_object(self, pk):
+        return get_object_or_404(Information.objects.select_related("individu"), pk=pk)
+
+    def check_permission(self, user, obj):
+        if user.categorie == "utilisateur":
+            return self._individu_accessible(obj.individu, user)
+        return False
+
+
+class ComptaOperationDocumentView(BaseDocumentView):
+    def get_object(self, pk):
+        return get_object_or_404(ComptaOperation.objects.select_related("compte__structure"), pk=pk)
+
+    def check_permission(self, user, obj):
+        if user.categorie == "utilisateur":
+            return obj.compte.structure in user.structures.all()
+        return False
+
+
+class PortailDocumentView(BaseDocumentView):
+    def get_object(self, pk):
+        return get_object_or_404(PortailDocument.objects.prefetch_related("activites"), pk=pk)
+
+    def check_permission(self, user, obj):
+        if user.categorie == "utilisateur":
+            doc_structures = set(obj.activites.values_list("structure_id", flat=True))
+            if obj.structure_id:
+                doc_structures.add(obj.structure_id)
+            user_structure_ids = set(user.structures.values_list("pk", flat=True))
+            return bool(doc_structures & user_structure_ids) or not doc_structures
+        if user.categorie == "famille":
+            famille = getattr(user, "famille", None)
+            if not famille:
+                return False
+            famille_activite_ids = set(
+                Inscription.objects.filter(famille=famille).values_list("activite_id", flat=True)
+            )
+            doc_activite_ids = set(obj.activites.values_list("pk", flat=True))
+            return bool(famille_activite_ids & doc_activite_ids)
+        return False
+
+
+class PhotoDocumentView(BaseDocumentView):
+    def get_object(self, pk):
+        return get_object_or_404(Photo.objects.select_related("album__structure"), pk=pk)
+
+    def get_file_field(self, obj):
+        return obj.fichier
+
+    def check_permission(self, user, obj):
+        if user.categorie == "utilisateur":
+            return obj.album.structure in user.structures.all() if obj.album.structure else True
+        if user.categorie == "famille":
+            famille = getattr(user, "famille", None)
+            if not famille or not obj.album.structure:
+                return False
+            return Inscription.objects.filter(
+                famille=famille,
+                activite__structure=obj.album.structure,
+            ).exists()
+        return False

--- a/noethysweb/fiche_famille/views/famille_pieces.py
+++ b/noethysweb/fiche_famille/views/famille_pieces.py
@@ -113,7 +113,7 @@ class Liste(Page, crud.Liste):
             kwargs = view.kwargs
             # Ajoute l'id de la ligne
             kwargs["pk"] = instance.pk
-            document_url = f'/media/{instance.document}'
+            document_url = reverse('serve_piece_document', args=[instance.pk]) if instance.document else None
 
             # Récupération des informations pertinentes pour le titre du document
             type_piece = instance.type_piece.nom if instance.type_piece else ""
@@ -123,15 +123,13 @@ class Liste(Page, crud.Liste):
             # Construction du titre du document pour le lien de téléchargement
             titre_document = f"{type_piece} - {individu} - {famille}"
 
-            # Construction du lien de téléchargement avec l'icône et l'attribut download
-            bouton_telecharger = f'<a href="{document_url}" class="btn btn-default btn-xs" download="{titre_document}"><i class="fa fa-download"></i></a>'
-
             html = [
                 self.Create_bouton_modifier(url=reverse(view.url_modifier, kwargs=kwargs)),
                 self.Create_bouton_supprimer(url=reverse(view.url_supprimer, kwargs=kwargs)),
-                self.Create_bouton_ouvrir(url=document_url),
-                bouton_telecharger,
             ]
+            if document_url:
+                bouton_telecharger = f'<a href="{document_url}" class="btn btn-default btn-xs" download="{titre_document}"><i class="fa fa-download"></i></a>'
+                html += [self.Create_bouton_ouvrir(url=document_url), bouton_telecharger]
             return self.Create_boutons_actions(html)
 
 

--- a/noethysweb/individus/views/liste_pieces_fournies.py
+++ b/noethysweb/individus/views/liste_pieces_fournies.py
@@ -67,7 +67,7 @@ class Liste(Page, crud.Liste):
             return result
 
         def Get_actions_speciales(self, instance, *args, **kwargs):
-            document_url = f'/media/{instance.document}'
+            document_url = reverse('serve_piece_document', args=[instance.pk]) if instance.document else None
 
             # Récupération des informations pertinentes pour le titre du document
             type_piece = instance.type_piece.nom if instance.type_piece else instance.titre
@@ -77,15 +77,11 @@ class Liste(Page, crud.Liste):
             # Construction du titre du document pour le lien de téléchargement
             titre_document = f"{type_piece} - {individu} {famille}"
 
-            # Construction du lien de téléchargement avec l'icône et l'attribut download
-            bouton_telecharger = f'<a href="{document_url}" class="btn btn-default btn-xs" download="{titre_document}"><i class="fa fa-download"></i></a>'
-            bouton_ouvrir = f'<a href="{document_url}" class="btn btn-default btn-xs" target="_blank"><i class="fa fa-eye"></i></a>'
-
-            html = [
-                bouton_ouvrir,
-                bouton_telecharger,
-                self.Create_bouton_modifier(url=reverse("famille_pieces_modifier", kwargs={"idfamille": instance.famille.pk, "pk": instance.pk})),
-            ]
+            html = [self.Create_bouton_modifier(url=reverse("famille_pieces_modifier", kwargs={"idfamille": instance.famille.pk, "pk": instance.pk}))]
+            if document_url:
+                bouton_telecharger = f'<a href="{document_url}" class="btn btn-default btn-xs" download="{titre_document}"><i class="fa fa-download"></i></a>'
+                bouton_ouvrir = f'<a href="{document_url}" class="btn btn-default btn-xs" target="_blank"><i class="fa fa-eye"></i></a>'
+                html = [bouton_ouvrir, bouton_telecharger] + html
 
             return self.Create_boutons_actions(html)
 

--- a/noethysweb/noethysweb/urls.py
+++ b/noethysweb/noethysweb/urls.py
@@ -7,6 +7,7 @@ from django.urls import include, path
 from django.conf import settings
 from django.conf.urls.static import static
 from core.views import erreurs
+from core.views import media as media_views
 
 
 urlpatterns = [
@@ -43,6 +44,17 @@ for nom_plugin in settings.PLUGINS:
 # Ajout de l'URL du portail
 if settings.PORTAIL_ACTIF:
     urlpatterns.append(path(settings.URL_PORTAIL, include('portail.urls')))
+
+# Documents protégés — accessibles aux staff et aux familles
+urlpatterns += [
+    path('media/piece/<int:pk>/',            media_views.PieceDocumentView.as_view(),           name='serve_piece_document'),
+    path('media/quotient/<int:pk>/',         media_views.QuotientDocumentView.as_view(),        name='serve_quotient_document'),
+    path('media/assurance/<int:pk>/',        media_views.AssuranceDocumentView.as_view(),       name='serve_assurance_document'),
+    path('media/information/<int:pk>/',      media_views.InformationDocumentView.as_view(),     name='serve_information_document'),
+    path('media/compta_operation/<int:pk>/', media_views.ComptaOperationDocumentView.as_view(), name='serve_compta_operation_document'),
+    path('media/portail_document/<int:pk>/', media_views.PortailDocumentView.as_view(),         name='serve_portail_document'),
+    path('media/photo/<int:pk>/',            media_views.PhotoDocumentView.as_view(),           name='serve_photo_document'),
+]
 
 if settings.DEBUG:
     # Ajoute le répertoire Media

--- a/noethysweb/noethysweb/urls.py
+++ b/noethysweb/noethysweb/urls.py
@@ -56,11 +56,7 @@ urlpatterns += [
     path('media/photo/<int:pk>/',            media_views.PhotoDocumentView.as_view(),           name='serve_photo_document'),
 ]
 
-if settings.DEBUG:
-    # Ajoute le répertoire Media
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-
-    if settings.ENABLE_DEBUG_TOOLBAR:
+if settings.DEBUG and settings.ENABLE_DEBUG_TOOLBAR:
         # Ajoute le debugtoolbar
         import debug_toolbar
         urlpatterns = [

--- a/noethysweb/portail/templates/portail/album.html
+++ b/noethysweb/portail/templates/portail/album.html
@@ -28,8 +28,8 @@
             <div class="d-flex flex-wrap">
                 {% for photo in photos %}
                     <div class="p-1">
-                        <a href="{{ photo.fichier.url }}" data-toggle="lightbox" data-title="{{ photo.titre|default:'Sans titre' }}" data-gallery="gallery">
-                            <img class="img-fluid img-thumbnail" style="max-height: 150px;" src="{{ photo.fichier.url }}">
+                        <a href="{% url 'serve_photo_document' photo.pk %}" data-toggle="lightbox" data-title="{{ photo.titre|default:'Sans titre' }}" data-gallery="gallery">
+                            <img class="img-fluid img-thumbnail" style="max-height: 150px;" src="{% url 'serve_photo_document' photo.pk %}">
                         </a>
                     </div>
                 {% empty %}

--- a/noethysweb/portail/templates/portail/documents.html
+++ b/noethysweb/portail/templates/portail/documents.html
@@ -71,11 +71,11 @@
                     {% for document in liste_documents %}
                         <div class="card mb-4" style="margin-top: 1px;">
                             <div class="card-body pl-3 pr-3 pt-3 pb-1" style="background-color: #f4f6f9">
-                                <h5 class="card-title"><a href="{{ document.fichier.url }}" target="_blank" title="{% trans "Télécharger le document" %}">{{ document.titre }}</a></h5>
+                                <h5 class="card-title"><a href="{{ document.url }}" target="_blank" title="{% trans "Télécharger le document" %}">{{ document.titre }}</a></h5>
                                 <div class="card-text link-muted mt-1"><small>{{ document.texte|default:"&nbsp;" }}</small></div>
                                 <span class="mailbox-attachment-size clearfix mt-1 mb-2">
                                     <span>{{ document.fichier.size|filesizeformat }} - {{ document.extension|upper }}</span>
-                                    <a href="{{ document.fichier.url }}" class="btn btn-default btn-sm float-right" target="_blank" title="{% trans "Télécharger le document" %}"><i class="fa fa-download"></i></a>
+                                    <a href="{{ document.url }}" class="btn btn-default btn-sm float-right" target="_blank" title="{% trans "Télécharger le document" %}"><i class="fa fa-download"></i></a>
                                 </span>
                             </div>
                         </div>
@@ -105,7 +105,7 @@
                                 <td>{{ piece.individu.prenom }}</td>
                                 <td>{{ piece.type_piece.nom|default:piece.titre }}</td>
                                 <td>
-                                    <a href="{{ MEDIA_URL }}{{ piece.document }}" class="btn btn-primary btn-xs bouton_telecharger" target="_blank" title="{% trans "Ouvrir le document" %}"><i class="fa fa-eye"></i> </a>
+                                    <a href="{% url 'serve_piece_document' piece.pk %}" class="btn btn-primary btn-xs bouton_telecharger" target="_blank" title="{% trans "Ouvrir le document" %}"><i class="fa fa-eye"></i> </a>
                                     <a href="{% url 'portail_documents_modifier' piece.pk %}" class="btn btn-warning btn-xs" title="{% trans "Modifier le document" %}"> <i class="fa fa-pencil"></i> </a>
                                     <form action="{% url 'supprimer_piece' pk=piece.pk %}" method="post" style="display: inline;" onsubmit="return confirm('Êtes-vous sûr de vouloir supprimer cette pièce ?');">
                                         {% csrf_token %}

--- a/noethysweb/portail/templates/portail/renseignements.html
+++ b/noethysweb/portail/templates/portail/renseignements.html
@@ -233,11 +233,11 @@
                     {% for document in liste_documents %}
                         <div class="card mb-4" style="margin-top: 1px;">
                             <div class="card-body pl-3 pr-3 pt-3 pb-1" style="background-color: #f4f6f9">
-                                <h5 class="card-title"><a href="{{ document.fichier.url }}" target="_blank" title="{% trans "Télécharger le document" %}">{{ document.titre }}</a></h5>
+                                <h5 class="card-title"><a href="{{ document.url }}" target="_blank" title="{% trans "Télécharger le document" %}">{{ document.titre }}</a></h5>
                                 <div class="card-text link-muted mt-1"><small>{{ document.texte|default:"&nbsp;" }}</small></div>
                                 <span class="mailbox-attachment-size clearfix mt-1 mb-2">
                                     <span>{{ document.fichier.size|filesizeformat }} - {{ document.extension|upper }}</span>
-                                    <a href="{{ document.fichier.url }}" class="btn btn-default btn-sm float-right" target="_blank" title="{% trans "Télécharger le document" %}"><i class="fa fa-download"></i></a>
+                                    <a href="{{ document.url }}" class="btn btn-default btn-sm float-right" target="_blank" title="{% trans "Télécharger le document" %}"><i class="fa fa-download"></i></a>
                                 </span>
                             </div>
                         </div>
@@ -267,7 +267,7 @@
                                 <td>{{ piece.individu.prenom }}</td>
                                 <td>{{ piece.type_piece.nom|default:piece.titre }}</td>
                                 <td>
-                                    <a href="{{ MEDIA_URL }}{{ piece.document }}" class="btn btn-primary btn-xs bouton_telecharger" target="_blank" title="{% trans "Ouvrir le document" %}"><i class="fa fa-eye"></i> </a>
+                                    <a href="{% url 'serve_piece_document' piece.pk %}" class="btn btn-primary btn-xs bouton_telecharger" target="_blank" title="{% trans "Ouvrir le document" %}"><i class="fa fa-eye"></i> </a>
                                     <a href="{% url 'portail_documents_modifier' piece.pk %}" class="btn btn-warning btn-xs" title="{% trans "Modifier le document" %}"> <i class="fa fa-pencil"></i> </a>
                                     <form action="{% url 'supprimer_piece' pk=piece.pk %}" method="post" style="display: inline;" onsubmit="return confirm('Êtes-vous sûr de vouloir supprimer cette pièce ?');">
                                         {% csrf_token %}

--- a/noethysweb/portail/views/documents.py
+++ b/noethysweb/portail/views/documents.py
@@ -7,6 +7,7 @@ import logging
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib import messages
+from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
@@ -46,7 +47,8 @@ class View(CustomView, TemplateView):
                 "texte": document.texte,
                 "fichier": document.document,
                 "couleur_fond": document.couleur_fond,
-                "extension": document.Get_extension()
+                "extension": document.Get_extension(),
+                "url": reverse('serve_portail_document', args=[document.iddocument]),
             })
         for unite_consentement in utils_approbations.Get_approbations_requises(
                 famille=self.request.user.famille,
@@ -57,7 +59,8 @@ class View(CustomView, TemplateView):
                 "texte": "Version du %s" % utils_dates.ConvertDateToFR(unite_consentement.date_debut),
                 "fichier": unite_consentement.document,
                 "couleur_fond": "primary",
-                "extension": unite_consentement.Get_extension()
+                "extension": unite_consentement.Get_extension(),
+                "url": unite_consentement.document.url,
             })
         context['liste_documents'] = liste_documents
 

--- a/noethysweb/portail/views/renseignements.py
+++ b/noethysweb/portail/views/renseignements.py
@@ -6,6 +6,7 @@ import logging
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib import messages
+from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
@@ -95,7 +96,8 @@ class View(CustomView, crud.Modifier):
                 "texte": document.texte,
                 "fichier": document.document,
                 "couleur_fond": document.couleur_fond,
-                "extension": document.Get_extension()
+                "extension": document.Get_extension(),
+                "url": reverse('serve_portail_document', args=[document.iddocument]),
             })
         for unite_consentement in utils_approbations.Get_approbations_requises(
                 famille=self.request.user.famille,
@@ -106,7 +108,8 @@ class View(CustomView, crud.Modifier):
                 "texte": "Version du %s" % utils_dates.ConvertDateToFR(unite_consentement.date_debut),
                 "fichier": unite_consentement.document,
                 "couleur_fond": "primary",
-                "extension": unite_consentement.Get_extension()
+                "extension": unite_consentement.Get_extension(),
+                "url": unite_consentement.document.url,
             })
         context['liste_documents'] = liste_documents
 


### PR DESCRIPTION
## Summary

- Documents (Piece, Quotient, Assurance, Information, ComptaOperation, PortailDocument, Photo) were served directly by NGINX with no authentication check — any user who knew a UUID file path could download it
- Adds `core/views/media.py` with one CBV per document type, each enforcing its own permission logic before streaming the file via `FileResponse`
- Replaces all hardcoded `/media/<uuid>` links in Python views and templates with the new named URL patterns (`/media/piece/<pk>/`, etc.)

## Permission rules

| View | Staff | Family |
|---|---|---|
| Piece | Accessible via their structures/inscriptions | Own family or rattached individu |
| Quotient | Via structures | Own family |
| Assurance | Via individu access | Own famille |
| Information | Via structures | **Denied** (health info) |
| ComptaOperation | Account's structure in user's structures | **Denied** |
| PortailDocument | By structure | Activity enrollment intersection |
| Photo | By album structure | Inscription in that structure |

## Deployment note

Remove the direct `location /media/` static-serve block from NGINX so requests reach Gunicorn — the new URL patterns handle routing and permission checking.