### PR TITLE
Fix FieldError when removing recipients in editeur_emails saisie_libre

### DIFF
--- a/noethysweb/outils/views/editeur_emails_saisie_libre.py
+++ b/noethysweb/outils/views/editeur_emails_saisie_libre.py
@@ -68,9 +68,12 @@ class Liste(Page_destinataires, TemplateView):
             ThroughModel.objects.bulk_create([ThroughModel(mail_id=mail.pk, destinataire_id=destinataire.pk) for destinataire in destinataires])
 
         # Suppression des destinataires
-        for adresse in liste_adresses_existantes:
-            if adresse not in liste_adresses:
-                destinataires = Destinataire.objects.filter(categorie="saisie_libre", adresse=adresse, mail=mail)
-                destinataires.delete()
+        # Le champ "adresse" est chiffré : impossible de le filtrer en base (lookup "exact" non supporté).
+        # On filtre donc en Python sur les destinataires du mail.
+        adresses_a_supprimer = set(liste_adresses_existantes) - set(liste_adresses)
+        if adresses_a_supprimer:
+            for destinataire in Destinataire.objects.filter(categorie="saisie_libre", mail=mail):
+                if destinataire.adresse in adresses_a_supprimer:
+                    destinataire.delete()
 
         return HttpResponseRedirect(reverse_lazy("editeur_emails", kwargs={'pk': mail.pk}))

--- a/noethysweb/versions.txt
+++ b/noethysweb/versions.txt
@@ -1,3 +1,6 @@
+Version 1.3.5.6.60 (25/06/2026)
+- Fix FieldError when removing recipients in editeur_emails saisie_libre (encrypted adresse field)
+
 Version 1.3.5.6.59 (23/06/2026)
 - Fix structure field validation in notes form
 


### PR DESCRIPTION
## Problem

Posting to `/utilisateur/outils/editeur_emails/saisie_libre/<idmail>` to remove a recipient crashes with:

```
FieldError: Unsupported lookup 'exact' for EncryptedEmailField or join on the field not permitted
```

## Root cause

`Destinataire.adresse` is an encrypted field (`encrypt(models.EmailField(...))` in `core/models.py`). Encrypted fields store ciphertext with a random IV, so they do **not** support the `exact` lookup. The deletion loop in `editeur_emails_saisie_libre.py` filtered with `adresse=adresse`, which builds an `exact` lookup → `FieldError`.

## Fix

Filter the recipients to delete in Python instead of in the database, mirroring how the existing recipients list (`liste_adresses_existantes`) is already built.