### PR TITLE
docs: Django 3.2 → 5.2 LTS upgrade plan + manual test checklist

### DIFF
--- a/docs/django-5-upgrade/DEPENDENCIES.md
+++ b/docs/django-5-upgrade/DEPENDENCIES.md
@@ -1,0 +1,53 @@
+# Dependency compatibility matrix — Django 5.2 target
+
+Verified against the PyPI JSON API and package changelogs (early–mid 2026). Confirm exact
+resolved versions with a `pip install "Django>=5.2.8" -r requirements.txt` dry-run at
+execution time, since patch releases land continuously.
+
+## Python support
+Django 5.2 (LTS, 2025-04-02) supports **Python 3.10 / 3.11 / 3.12 / 3.13**.
+**Python 3.14 support was added in Django 5.2.8** → if you run 3.14, pin `Django>=5.2.8`.
+Recommendation: run CI + prod on **3.13** (or 3.14 with `Django>=5.2.8`).
+
+## Package matrix
+
+| Package (current) | 5.2 OK? | Target | Risk | Notes / gotchas |
+|---|---|---|---|---|
+| **django-cryptography 1.0** | ❌ (dead, max 4.0) | **django-cryptography-5 ==2.0.3** (saaspegasus fork) | 🔴 | Drop-in: same `from django_cryptography.fields import encrypt`. Fernet keyed off `SECRET_KEY` (+ optional `CRYPTOGRAPHY_SALT`) → existing IBAN/password/address ciphertext stays readable **iff those settings are unchanged**. Classifiers stop at 5.1; verify a read of existing rows in staging. Avoid the `django-cryptography-django5` fork (only claims ≤5.0). |
+| **django-datatable-view 2.1.6** | ⚠️ PyPI stale, but repo supports 5.2 | **install from Git @ `098e00e`** | 🟠 | **NOT abandoned** — repo actively maintained (last push 2026-05-07). PyPI is frozen at 2.1.6 (2021, Django ≤3.2). Commit `098e00e` (just before master bumped to Django-6-only) declares `django>=5.2`, classifiers Django 5.2 + 6.0, Python 3.12–3.14. Same package layout as 2.1.6 (`columns`/`datatables`/`helpers`/`views`) → imports intact. Pin the git SHA; verify API deltas across the 2021→2026 gap on your list views. Requires Python ≥3.12. Fallback if the API drifted too much: django-tables2. |
+| **django-crispy-forms 1.13.0** | ❌ | **2.6** + **crispy-bootstrap4 ==2026.2** | 🟠 | 2.x moved template packs out. Add both `crispy_forms` and `crispy_bootstrap4` to INSTALLED_APPS; `CRISPY_TEMPLATE_PACK` now raises if unset (already set). Removed: `FormHelper.form_style`, `html5_required`, `render_field(form_style=…)`. |
+| **django-csp 3.7** | ❌ | **4.0** | 🟠 | 4.0 replaces flat `CSP_*` settings with nested `CONTENT_SECURITY_POLICY = {"DIRECTIVES": {...}}`. Rewrite all CSP settings (see migration guide). |
+| **django-axes 5.26.0** | ❌ | **8.3.1** | 🟠 | Big jump. Breaking across 6/7/8.x: handler/backend refactor, `AXES_*` renames/removals, cache-key changes, `AxesStandaloneBackend` setup. Read the 6.0 migration notes. |
+| **django-select2 7.11.1** | ❌ | **8.4.8** | 🟠 | v8 **requires the admin app in INSTALLED_APPS** (present) **and a proper shared cache** (NOT LocMemCache) for model widgets → must configure `CACHES` (Redis/Memcached/DB). |
+| **django-sn 0.8.11.9** (summernote fork) | ❌ (stale) | **django-summernote ==0.8.20.0** | 🟡 | Abandon the fork, return to upstream `django-summernote` (actively maintained). Verify app-name/template differences vs the fork. |
+| **django-debug-toolbar 3.2.2** | ❌ | **7.0.0** | 🟢 | Dev-only. Just bump. |
+| **django-extensions 3.1.3** | ❌ | **4.1** | 🟢 | Straightforward. |
+| **django-cleanup 7.0.0** | ~ | **9.0.0** | 🟢 | Jazzband; follows Django supported versions. Simple bump. |
+| **django-storages 1.13.1** | ❌ | **1.14.6** | 🟢 | Declares ≤5.1, functional on 5.2. Bump again when a 5.2-classifier release lands. |
+| **django-dbbackup 3.3.0** | ❌ | **5.3.0** | 🟡 | Major jump; review 4.x changelog for command/settings changes. |
+| **django-crontab 0.7.1** | ~ (unmaintained) | keep 0.7.1 or migrate | 🟡 | Thin `crontab` wrapper, low Django coupling → usually still runs. If it breaks: `django-cron-django5`, system cron, or Celery beat. |
+| **django-formtools 2.3** | ❌ | **2.6.1** | 🟢 | Clean bump. |
+| **django-anymail 8.4** | ❌ | **15.0** | 🟡 | Big jump, stable API; check ESP backend notes. |
+| **django-resized 1.0.3** | ~ (max 5.1) | 1.0.3 (latest) | 🟢 | Already latest. Test image save/resize on 5.2. |
+| **django-multiselectfield 0.1.12** | ❌ | **1.0.1** | 🟠 | **1.0 breaking: integer choices dropped.** This repo uses integer keys in `JOURS_SEMAINE` → see blocker B5. |
+| **django-turnstile 0.1.3** | ❌ (max 4.0) | **replace → django-cf-turnstile** | 🟡 | Original near-abandoned. `django-cf-turnstile` (ronaldgrn) supports 4.2 + 5.2. Implicit widget rendering only. |
+| **django-upload-form 0.5.0** | ? (undeclared) | 0.5.0 (latest) | 🟡 | Thin Form wrapper; likely runs but untested on 5.2 — verify upload flow. |
+| **django-appconf 1.0.5** | ❌ | **1.2.0** | 🟢 | Clean bump (transitive dep of others too). |
+| **django-ipware 4.0.2** | ~ | **7.0.1** | 🟡 | 7.x wraps `python-ipware`; `get_client_ip` return signature evolved — check call sites. |
+| **django-ranged-response 0.2.0** | ~ (abandoned) | 0.2.0 (only version) | 🟢 | Tiny StreamingHttpResponse subclass, no Django coupling. Works on 5.2. |
+
+## Config rewrites required (not just version bumps)
+- **django-csp 4.0** → nested `CONTENT_SECURITY_POLICY` dict.
+- **django-crispy-forms 2.x** → add `crispy-bootstrap4` package + app.
+- **django-axes 8.x** → settings/backend migration.
+- **django-select2 8.x** → add a shared `CACHES` backend (LocMemCache won't do).
+
+## Replace / abandon
+- `django-cryptography` → `django-cryptography-5`
+- `django-datatable-view` → **keep it**, install from Git @ `098e00e` (PyPI stale but repo active & 5.2-ready); django-tables2 only as a fallback if the API drifted
+- `django-turnstile` → `django-cf-turnstile`
+- `django-sn` → upstream `django-summernote`
+- `django-crontab` → keep unless it breaks, else `django-cron-django5` / system cron
+
+## Data-affecting
+- **django-multiselectfield 1.0** dropped integer choices → audit `JOURS_SEMAINE` (blocker B5).

--- a/docs/django-5-upgrade/MANUAL_TESTS.md
+++ b/docs/django-5-upgrade/MANUAL_TESTS.md
@@ -1,0 +1,172 @@
+# Django 5.2 upgrade — manual test checklist
+
+These are the features that must be tested **by hand** after the upgrade. They are
+listed here because they are too costly or too fragile to automate reliably:
+external services (payment gateways, email, Dropbox), binary output (PDF / Word / SEPA
+files opened in real software), scheduled jobs, encrypted data round-trips, and
+rich-client JS widgets.
+
+> **How to use:** run through this on a **copy of production data** (real encrypted
+> fields, real volumes) against the upgraded build, before deploying. Tick each box,
+> note the tester + date. Anything that fails → open an issue and link it here.
+
+Legend: `[ ]` not tested · `[x]` passed · `[!]` failed (link issue)
+
+---
+
+## 0. Critical prerequisites (do first — everything else depends on these)
+
+- [ ] **Encrypted fields decrypt correctly.** Open a family/individu created *before*
+      the upgrade and confirm encrypted fields are still readable (not garbage / not
+      errors). Fields encrypted via `django_cryptography`: postal address, email,
+      SEPA IBAN / BIC / ICS code, bank account numbers, mail-server password/host/user.
+      → This validates that the cryptography replacement package uses the **same key
+      derivation from `SECRET_KEY`**. If this fails, STOP — do not deploy.
+- [ ] Save a record with an encrypted field, reload it, confirm the new value persists
+      and re-reads correctly (write path, not just read path).
+- [ ] Log in as an existing administrator, an existing "utilisateur" (bureau), and an
+      existing portail family account — all with pre-upgrade password hashes.
+- [ ] Static files load (CSS/JS/images present, no 404s) — the `STORAGES` /
+      manifest-storage migration is exercised here. Check both `administrateur/` and
+      `utilisateur/` and the portail.
+
+---
+
+## 1. Authentication & security
+
+- [ ] Login / logout for each role (admin, bureau, portail family).
+- [ ] django-axes brute-force lockout: fail login N times → account/IP locked →
+      lockout page (`/locked`) shown → cooloff releases it.
+- [ ] Password expiry flow (`DUREE_VALIDITE_MDP`): expired password forces reset.
+- [ ] Password reset by email (token email arrives, link works, sets new password).
+- [ ] Turnstile captcha on the portail login (if `TURNSTILE_ENABLE=True` in prod).
+- [ ] CSP headers present and pages render (maps, Google fonts, YouTube embeds,
+      Turnstile challenge, jsdelivr/cdnjs scripts all load — check browser console for
+      CSP violations). django-csp 4.x changed the settings format — verify nothing is
+      silently blocked.
+- [ ] Session behaviour: "remember me", session timeout, X-Frame-Options / clickjacking.
+
+## 2. Families & individuals (fiche_famille / fiche_individu / individus)
+
+- [ ] Create a new family, add individuals, set relationships.
+- [ ] Edit a family with encrypted fields (address, bank details) and save.
+- [ ] Photo upload + resize (django-resized → WEBP conversion, 1024px cap) displays.
+- [ ] Document upload (allowed types, 10 MB limit enforced).
+- [ ] Summernote rich-text editors (notes, portail texts): toolbar loads, image insert,
+      content saves and renders.
+- [ ] Select2 dropdowns (autocomplete search) work across forms.
+- [ ] DataTables lists (families, individuals): pagination, search, sort, per-column
+      filters, row actions.
+
+## 3. Activities & registrations (consommations / parametrage activités)
+
+- [ ] Create/configure an activity, groups, units, rates (tarifs).
+- [ ] Register an individual, fill the consumption grid (grille), save.
+- [ ] Bulk registration / calendar operations.
+- [ ] Waitlist / capacity limits behave.
+
+## 4. Billing (facturation)
+
+- [ ] Generate invoices for a period (batch run over many families).
+- [ ] Invoice PDF: open in a real PDF reader — layout, totals, logo, barcode
+      (pystrich/reportlab) all correct.
+- [ ] Email invoices to families (see §8 email).
+- [ ] Credit notes / avoirs, re-billing, deletion of a billing run.
+- [ ] Quotient familial / CAF rate calculations produce the same numbers as pre-upgrade.
+
+## 5. Payments & gateways (reglements)
+
+> External services — cannot be automated. Use gateway sandbox/test credentials.
+
+- [ ] Record a manual payment (règlement), allocate to invoices, print receipt.
+- [ ] SEPA direct debit (prélèvement): generate the SEPA XML file → validate it opens
+      in the bank tool / passes an ISO 20022 validator. IBAN/BIC come from **encrypted**
+      fields — confirm they are correct in the file.
+- [ ] Online payment via each configured gateway: **Stripe**, **eopayment** (PayFiP /
+      other), **HelloAsso** — run a sandbox transaction end-to-end, confirm callback /
+      webhook marks the payment as received.
+- [ ] TPE / card terminal token flow (PaiementTPE / TokenHA) if used.
+- [ ] Refund / cancellation path.
+
+## 6. Accounting (comptabilite)
+
+- [ ] Ventilation / journal entries generated from payments.
+- [ ] Accounting exports (check the exported file opens correctly in target software).
+
+## 7. Documents: PDF, Word mail-merge, exports
+
+- [ ] Word mail-merge (docx-mailmerge2, `utils_fusion_word`): generate a document from a
+      Word template with merge fields → open in Word/LibreOffice, fields filled.
+- [ ] Configurable Word templates (parametrage/modeles_word) upload + generate.
+- [ ] All PDF outputs (attestations, receipts, invoices, lists): open each in a real
+      reader — fonts, accents (French), tables, images render.
+- [ ] Excel/CSV exports (xlsxwriter/xlrd): open in Excel/LibreOffice, encoding + accents OK.
+
+## 8. Email (django-anymail + editeur_emails)
+
+- [ ] Send a single email from the email editor (summernote HTML body).
+- [ ] Bulk email send to a family list.
+- [ ] Anymail ESP delivery (real ESP in prod config): message actually delivered,
+      tracking/webhook works.
+- [ ] Attachments (invoice PDF) attach and open.
+- [ ] Admin error emails (`mail_admins`) still fire on a 500 in production.
+
+## 9. Family portal (portail)
+
+- [ ] Family self-registration / account creation flow.
+- [ ] Portail login (+ Turnstile if enabled).
+- [ ] View & edit family/individual info from the portail (writes to encrypted fields).
+- [ ] Online registration to an activity.
+- [ ] Online payment from the portail (ties into §5 gateways).
+- [ ] Document consultation / upload from the portail.
+- [ ] Messaging / notes between structure and family.
+- [ ] (See existing scenarios in `noethysweb/tests/portail/` — extend, don't force-green.)
+
+## 10. Backups & scheduled jobs
+
+- [ ] `outils/views/sauvegarde_creer` — create a manual backup (django-dbbackup).
+- [ ] Dropbox backup: refresh-token flow (`get_refresh_token_dropbox`) + a backup
+      actually lands in Dropbox.
+- [ ] Restore a backup into a scratch DB and confirm integrity (esp. encrypted fields).
+- [ ] django-crontab jobs (`noethysweb/cron.py`): re-add crontab
+      (`manage.py crontab add`) and confirm each scheduled job runs (reminders, auto
+      backups, etc.).
+
+## 11. Tools & admin (outils / aide / collaborateurs)
+
+- [ ] Django admin site loads and CRUD works for a couple of models.
+- [ ] Collaborateurs (staff) management.
+- [ ] Aide / help pages render.
+- [ ] Any import tools (import familles/individus) run to completion.
+- [ ] Multi-select fields (django-multiselectfield) save/read correctly.
+
+## 12. Cross-cutting / regressions to eyeball
+
+- [ ] French localisation: dates as `dd/mm/YYYY`, decimal comma, phone formatting
+      (`USE_L10N` was removed in Django 5.0 — formats must still be French).
+- [ ] Timezone: `USE_TZ=False` — datetimes display as before (no UTC shift).
+- [ ] File upload widget (django-upload-form) drag/drop + size validation.
+- [ ] Plugins (if any enabled in prod) load and their URLs resolve.
+- [ ] No deprecation warnings / errors in `debug.log` after a normal browsing session.
+- [ ] Performance sanity: large DataTables lists and billing runs are not dramatically
+      slower.
+
+---
+
+## Sign-off
+
+| Area | Tester | Date | Result |
+|------|--------|------|--------|
+| Critical prerequisites (§0) | | | |
+| Auth & security (§1) | | | |
+| Families/individuals (§2) | | | |
+| Activities (§3) | | | |
+| Billing (§4) | | | |
+| Payments (§5) | | | |
+| Accounting (§6) | | | |
+| Documents (§7) | | | |
+| Email (§8) | | | |
+| Portail (§9) | | | |
+| Backups/cron (§10) | | | |
+| Tools/admin (§11) | | | |
+| Cross-cutting (§12) | | | |

--- a/docs/django-5-upgrade/PLAN.md
+++ b/docs/django-5-upgrade/PLAN.md
@@ -1,0 +1,130 @@
+# Upgrade plan: Django 3.2 → 5.2 LTS
+
+**Current:** Django `3.2.19` · **Target:** Django `5.2.x` (LTS, supported until Apr 2028).
+**Codebase:** ~1,400 Python files, 253 migrations, custom user model, encrypted DB
+fields, family portal, billing, payment gateways.
+
+This is a **4-major-version jump** (3.2 → 4.0 → 4.1 → 4.2 → 5.0 → 5.1 → 5.2). We do it
+in **staged steps**, not one leap: each Django minor is a checkpoint where tests must be
+green before moving on. The dependency stack is the hard part, not Django itself — the
+code is already mostly modern (uses `path()`, no `ugettext`/`is_ajax`/`url()`).
+
+> Progress is tracked with the checkboxes below. Tick as you go; keep this file in the repo.
+
+---
+
+## Known code-level blockers (found in this repo)
+
+| # | Location | Issue | Removed in | Fix |
+|---|----------|-------|-----------|-----|
+| B1 | `noethysweb/settings.py:176` | `USE_L10N = True` | 5.0 | Delete the line — localization is always on in 5.x. Confirm French formats still apply (they will; `LANGUAGE_CODE='fr'`, `DATE_FORMAT` kept). |
+| B2 | `noethysweb/settings.py:191` | `STATICFILES_STORAGE = ...` | 5.1 | Migrate to the `STORAGES` dict (test settings already do this — mirror it, keeping the custom `ForgivingManifestStaticFilesStorage`). |
+| B3 | `core/models.py:12,271` | `from django.core.files.storage import get_storage_class` | 5.1 | Replace `get_storage_class(path)` with `django.utils.module_loading.import_string(path)` — returns the same class, drop-in. |
+| B4 | `django_cryptography` (encrypted fields) | Package abandoned; no Django 4.2/5.x support | — | **Critical.** Replace with `django-cryptography-5==2.0.3` (drop-in, same API, Fernet keyed off `SECRET_KEY`). Existing ciphertext stays readable **iff `SECRET_KEY`/`CRYPTOGRAPHY_SALT` unchanged**. See manual test §0. |
+| B5 | `core/models.py:34` `JOURS_SEMAINE = [(0,"L"),(1,"M"),…]` | `django-multiselectfield` 1.0 **drops integer choices**; used by `jours_scolaires`/`jours_vacances` on 3 models | (1.0) | Either pin multiselectfield to a pre-1.0 version compatible with 5.2, or convert `JOURS_SEMAINE` keys to strings (`"0"`,`"1"`,…) **with a data migration** for existing comma-separated integer values. Data-affecting — test carefully. |
+| B6 | `settings.py` (no `CACHES`) | `django-select2` v8 needs a **shared cache** (LocMemCache default won't work for model widgets) | — | Add a `CACHES` backend (Redis/Memcached/DB/file). Affects Select2 autocomplete across the app. |
+
+Not found (good — nothing to fix): `ugettext*`, `force_text`/`smart_text`,
+`request.is_ajax()`, `NullBooleanField`, `default_app_config`, `providing_args`,
+`index_together`, `django.conf.urls.url()`, `pytz`, `timezone.utc`.
+
+Watch items:
+- **CSRF (Django 4.0):** `Origin` header is now checked on secure requests. If the prod
+  site is behind a proxy / uses a non-default port, add `CSRF_TRUSTED_ORIGINS`
+  (must include scheme, e.g. `https://example.com`).
+- **`SECRET_KEY_FALLBACKS`** available since 4.1 — useful if we ever rotate the key, but
+  do NOT rotate `SECRET_KEY` during this upgrade (it is the encryption key — see B4).
+
+---
+
+## Dependency strategy
+
+The Django bump is gated by third-party packages. Target versions are confirmed by the
+compatibility check (`docs/django-5-upgrade/DEPENDENCIES.md`). High-risk ones first:
+
+Full verified table in **`DEPENDENCIES.md`**. Highest-risk first:
+
+| Package | Current → Target | Risk | Notes |
+|---------|------------------|------|-------|
+| `django-cryptography` | 1.0 → **django-cryptography-5 2.0.3** | 🔴 critical | Drop-in fork, same API, Fernet keyed off `SECRET_KEY`. **Data-compat is the #1 risk** — encrypted IBAN/BIC/passwords/addresses must still decrypt. Test on prod-data copy before deploy. |
+| `django-datatable-view` | 2.1.6 → **git @ `098e00e`** | 🟠 medium | **Actively maintained** (last push 2026-05-07); PyPI is just stale. Commit `098e00e` supports `django>=5.2` (same package layout as 2.1.6). Install from Git, pin the SHA, verify API deltas on list views. Requires Python ≥3.12. Not a rewrite. |
+| `django-multiselectfield` | 0.1.12 → **1.0.1** | 🟠 medium | 1.0 drops integer choices → blocker **B5** (data migration for `JOURS_SEMAINE`). |
+| `django-crispy-forms` | 1.13.0 → **2.6** (+ `crispy-bootstrap4 2026.2`) | 🟠 medium | 2.x moved template packs out. Author already anticipated this (commented code in settings). 311 files use crispy. |
+| `django-csp` | 3.7 → **4.0** | 🟠 medium | 4.0 replaces `CSP_*` settings with a nested `CONTENT_SECURITY_POLICY` dict → rewrite all `CSP_*` in settings.py. |
+| `django-axes` | 5.26.0 → **8.3.1** | 🟠 medium | Big jump; `AXES_*` renames, backend/handler refactor, cache-key changes. Read 6.0 migration notes. |
+| `django-select2` | 7.11.1 → **8.4.8** | 🟠 medium | v8 needs a shared cache backend → blocker **B6** (`CACHES`). |
+| `django-turnstile` | 0.1.3 → **replace (django-cf-turnstile)** | 🟡 low | Original abandoned; `django-cf-turnstile` supports 5.2. |
+| `django-sn` (summernote fork) | 0.8.11.9 → **django-summernote 0.8.20.0** | 🟡 low | Abandon fork, return to upstream. |
+| `django-dbbackup` | 3.3.0 → **5.3.0** | 🟡 low | Major jump; review 4.x changelog. |
+| `django-anymail` | 8.4 → **15.0** | 🟡 low | Big jump, stable API; check ESP notes. |
+| `django-ipware` | 4.0.2 → **7.0.1** | 🟡 low | `get_client_ip` return signature evolved — check call sites. |
+| `django-crontab` | 0.7.1 (keep) | 🟡 low | Unmaintained but thin; keep unless it breaks (fallback: system cron / django-cron-django5). |
+| `-debug-toolbar 7.0.0`, `-extensions 4.1`, `-cleanup 9.0.0`, `-storages 1.14.6`, `-formtools 2.6.1`, `-appconf 1.2.0`, `-resized 1.0.3`, `-upload-form 0.5.0`, `-ranged-response 0.2.0` | bump | 🟢 | Low risk. See DEPENDENCIES.md. |
+
+**Python:** Django 5.2 supports 3.10–3.13; **3.14 support was added in Django 5.2.8**.
+CI currently runs 3.10 → move CI + prod to **3.13** (or 3.14 with `Django>=5.2.8`).
+
+---
+
+## Phased execution
+
+### Phase 0 — Safety net & baseline
+- [ ] Do the work on a branch; never rotate `SECRET_KEY`.
+- [ ] Get a **copy of production data** (with real encrypted fields) into a staging DB.
+- [ ] Confirm current test suite is green on 3.2 as the baseline (`pytest`).
+- [ ] Enable deprecation warnings: run `python -W error::DeprecationWarning manage.py test`
+      (or set filters) so each step surfaces removals early.
+- [ ] Bump CI Python to the target (3.12/3.13) on a scratch branch to catch env issues.
+
+### Phase 1 — Resolve the dependency wall (before touching Django)
+- [ ] Finalize `DEPENDENCIES.md` target versions (pip resolver dry-run against Django 5.2).
+- [ ] **B4 — cryptography (go/no-go gate):** swap `django-cryptography` →
+      `django-cryptography-5==2.0.3`; on the prod-data copy verify old ciphertext
+      decrypts **and** new writes round-trip (manual test §0). Never change `SECRET_KEY`.
+- [ ] **datatable-view:** install from Git @ `098e00e` (`pip install
+      git+https://github.com/pivotal-energy-solutions/django-datatable-view.git@098e00e`);
+      spike one list end-to-end (search/sort/paginate/row actions) to surface any API
+      deltas since 2.1.6, then confirm the rest. Fall back to django-tables2 only if the
+      API drifted too far. Requires Python ≥3.12.
+- [ ] **B5 — multiselectfield:** decide pin-vs-convert for `JOURS_SEMAINE`; if converting
+      keys to strings, write + test the data migration.
+- [ ] **B6 — cache:** add a `CACHES` backend for django-select2 v8.
+- [ ] crispy-forms 2.x + `crispy-bootstrap4` (add to INSTALLED_APPS); smoke-test forms.
+- [ ] django-csp 4.0: rewrite `CSP_*` → `CONTENT_SECURITY_POLICY` dict; check no CSP
+      violations in browser console (manual test §1).
+- [ ] django-axes 8.x: apply setting/backend migration; verify lockout still works.
+- [ ] Replace `django-turnstile` → `django-cf-turnstile`; `django-sn` → `django-summernote`.
+
+### Phase 2 — Django 4.0 → 4.1 → 4.2 (each a checkpoint)
+- [ ] Fix **B1** (`USE_L10N`) and any 4.x deprecation warnings.
+- [ ] Add `CSRF_TRUSTED_ORIGINS` for prod if needed (4.0 CSRF change).
+- [ ] `makemigrations --check` clean; `migrate` on staging DB clean.
+- [ ] `pytest` green at 4.2 (LTS) — treat 4.2 as a solid intermediate landing point.
+
+### Phase 3 — Django 5.0 → 5.1 → 5.2
+- [ ] At 5.0: confirm B1 done (`USE_L10N` gone).
+- [ ] At 5.1: fix **B2** (`STORAGES`) and **B3** (`import_string`).
+- [ ] Land on **5.2.x**; pin exact versions in `requirements.txt`.
+- [ ] `manage.py check --deploy` clean; `makemigrations --check` clean.
+- [ ] `pytest` green; `collectstatic` succeeds with the new `STORAGES` config.
+
+### Phase 4 — Verification & deploy
+- [ ] Full automated suite green (unit + Playwright) on target Python.
+- [ ] Work through **`MANUAL_TESTS.md`** on the prod-data copy — §0 first (go/no-go).
+- [ ] Deploy to staging mirroring prod (MySQL, gunicorn, real ESP/gateways in sandbox).
+- [ ] Re-run crontab (`manage.py crontab add`), verify scheduled jobs.
+- [ ] Production deploy in a maintenance window with a tested rollback (DB backup + prior
+      release). **Keep the same `SECRET_KEY`.**
+
+---
+
+## Rollback
+
+- Keep the pre-upgrade release deployable and a DB backup taken immediately before deploy.
+- Because encrypted fields are tied to `SECRET_KEY`, rolling *back* the code is safe as
+  long as `SECRET_KEY` never changed. Never change it as part of this upgrade.
+
+## Deliverables in this folder
+- `PLAN.md` — this file (staged plan + checklist).
+- `MANUAL_TESTS.md` — features to test by hand after the upgrade.
+- `DEPENDENCIES.md` — verified per-package target versions and gotchas.

--- a/noethysweb/collaborateurs/views/collaborateur_pieces.py
+++ b/noethysweb/collaborateurs/views/collaborateur_pieces.py
@@ -137,4 +137,4 @@ class Saisie_rapide(Page, RedirectView):
         piece = PieceCollaborateur.objects.create(type_piece=type_piece, collaborateur=collaborateur,
                                                   date_debut=date_debut, date_fin=date_fin)
         messages.add_message(self.request, messages.SUCCESS, "La pièce '%s' a été créée avec succès" % piece.Get_nom())
-        return self.request.META['HTTP_REFERER']
+        return self.request.headers['referer']

--- a/noethysweb/core/admin.py
+++ b/noethysweb/core/admin.py
@@ -49,6 +49,7 @@ class UserEditForm(UserChangeForm):
 
 # --------------------------- Utilisateurs ----------------------------
 
+@admin.register(Utilisateur_Utilisateur)
 class UtilisateurAdmin(UserAdmin):
     form = UserEditForm
 
@@ -85,11 +86,11 @@ class Utilisateur_Utilisateur(Utilisateur):
         proxy = True
         verbose_name = "Utilisateur"
 
-admin.site.register(Utilisateur_Utilisateur, UtilisateurAdmin)
 
 
 # --------------------------- Familles ----------------------------
 
+@admin.register(Utilisateur_Famille)
 class FamilleAdmin(UserAdmin):
     form = UserEditForm
 
@@ -126,4 +127,3 @@ class Utilisateur_Famille(Utilisateur):
         verbose_name = "Famille"
 
 
-admin.site.register(Utilisateur_Famille, FamilleAdmin)

--- a/noethysweb/core/decorators.py
+++ b/noethysweb/core/decorators.py
@@ -33,7 +33,7 @@ def secure_ajax(function):
     """ A associer aux requêtes AJAX """
     def _function(request, *args, **kwargs):
         # Vérifie que c'est une requête AJAX
-        if not request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest':
+        if not request.headers.get('x-requested-with') == 'XMLHttpRequest':
             return HttpResponseBadRequest()
         # Vérifie que l'utilisateur est authentifié
         if not request.user.is_authenticated:
@@ -51,7 +51,7 @@ def secure_ajax_portail(function):
     """ A associer aux requêtes AJAX """
     def _function(request, *args, **kwargs):
         # Vérifie que c'est une requête AJAX
-        if not request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest':
+        if not request.headers.get('x-requested-with') == 'XMLHttpRequest':
             return HttpResponseBadRequest()
         # Vérifie que l'utilisateur est authentifié
         if not request.user.is_authenticated:

--- a/noethysweb/core/forms/filtre_liste.py
+++ b/noethysweb/core/forms/filtre_liste.py
@@ -138,7 +138,7 @@ def Supprimer_filtre(request, idfiltre=None):
     """ Suppression du filtre de liste """
     FiltreListe.objects.get(pk=idfiltre).delete()
     # Recharge la page
-    return redirect(request.META["HTTP_REFERER"])
+    return redirect(request.headers["referer"])
 
 
 class Formulaire(FormulaireBase, forms.Form):

--- a/noethysweb/individus/views/importation_photos.py
+++ b/noethysweb/individus/views/importation_photos.py
@@ -18,7 +18,7 @@ from individus.forms.importation_photos import Formulaire, Formulaire_importatio
 
 def Importer_photos_individus(request):
     assert request.method == 'POST'
-    assert request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'
+    assert request.headers.get('x-requested-with') == 'XMLHttpRequest'
     form = Formulaire_importation(request.POST, request.FILES)
     if form.is_valid():
         uuid_lot = form.form_valid(request)

--- a/noethysweb/noethysweb/settings.py
+++ b/noethysweb/noethysweb/settings.py
@@ -173,7 +173,6 @@ AUTH_PASSWORD_VALIDATORS = [
 LANGUAGE_CODE = 'fr'
 TIME_ZONE = 'Europe/Paris'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = False
 DATE_FORMAT = "d/m/Y"
 TELEPHONE_FORMAT_FR = True
@@ -188,7 +187,12 @@ LOCALE_PATHS = (
 # URL publique pour accéder aux fichiers statiques
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
-STATICFILES_STORAGE = 'noethysweb.storage.ForgivingManifestStaticFilesStorage'
+STORAGES = {
+    **STORAGES,
+    "staticfiles": {
+        "BACKEND": 'noethysweb.storage.ForgivingManifestStaticFilesStorage',
+    },
+}
 
 # Media (uploads)
 MEDIA_URL = '/media/'

--- a/noethysweb/parametrage/views/albums.py
+++ b/noethysweb/parametrage/views/albums.py
@@ -14,7 +14,7 @@ from parametrage.forms.albums import Formulaire_album, Formulaire_photo, Formula
 
 def Importer_photos_album(request):
     assert request.method == 'POST'
-    assert request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'
+    assert request.headers.get('x-requested-with') == 'XMLHttpRequest'
     form = Formulaire_importation(request.POST, request.FILES, idalbum=request.POST.get("idalbum"))
     if form.is_valid():
         url = form.form_valid(request)

--- a/noethysweb/parametrage/views/archive.py
+++ b/noethysweb/parametrage/views/archive.py
@@ -27,7 +27,7 @@ class ToggleArchiveView(View):
                 redirect_url = "structures_liste"
             else:
                 messages.error(request, "Type d'objet non défini.")
-                return redirect(request.META.get("HTTP_REFERER", "/"))
+                return redirect(request.headers.get("referer", "/"))
 
             # Exécute la procédure
             proc = self.procedure_class()


### PR DESCRIPTION
## What

Adds planning docs (no code changes) for the Django **3.2 → 5.2 LTS** upgrade, under `docs/django-5-upgrade/`:

- **`PLAN.md`** — staged 3.2→4.2→5.2 upgrade (checkpoint per Django minor), code-level blockers, verified dependency targets, phased checklist, rollback strategy.
- **`MANUAL_TESTS.md`** — the by-hand test checklist for things too costly/fragile to automate: encrypted-field round-trips, payment gateways (Stripe/eopayment/HelloAsso), SEPA XML, PDF/Word/Excel output, ESP email, Dropbox backups, cron jobs, JS widgets. §0 is a go/no-go gate.
- **`DEPENDENCIES.md`** — verified per-package target versions and gotchas for all 22 Django packages + Python support matrix.

## Key findings

- Code is mostly modern (uses `path()`, no `ugettext`/`is_ajax()`/`url()`/`pytz`). Six concrete blockers: `USE_L10N` (B1), `STATICFILES_STORAGE`→`STORAGES` (B2), `get_storage_class` (B3), `django-cryptography` swap (B4, critical/data-compat), `MultiSelectField` integer choices (B5), missing `CACHES` for select2 v8 (B6).
- **Critical gate:** `django-cryptography` → `django-cryptography-5`; encrypted IBAN/passwords stay readable only if `SECRET_KEY` is unchanged.
- `django-datatable-view`: **not** abandoned — install from Git @ `098e00e` (supports Django 5.2); PyPI release is just stale.

## Scope

Docs only — **nothing implemented yet.** Intended as the reviewable plan before starting Phase 1.