### PR TITLE
Corrige TypeError au tri de la liste des demandes de vérification

### DIFF
--- a/noethysweb/individus/views/demande_approbation.py
+++ b/noethysweb/individus/views/demande_approbation.py
@@ -211,7 +211,10 @@ class Liste(Page, crud.Liste):
         filtres = [ "individu__nom", "individu__prenom","besoin_certification", "last_approbation"]
         actions = columns.TextColumn("Actions", sources=None, processor="Get_actions_speciales")
         individu = columns.CompoundColumn("Individu", sources=["individu__nom", "individu__prenom"])
-        last_approbation = columns.TextColumn("Date de dernière vérification", sources=["last_certification_date"], processor="Get_certification_date")
+        # Source de tri via un callable : on renvoie toujours un datetime (jamais None ni "")
+        # sinon datatableview mélange datetime et empty_value (str) lors du tri manuel et lève
+        # "'<' not supported between instances of 'str' and 'datetime.datetime'".
+        last_approbation = columns.TextColumn("Date de dernière vérification", sources=[lambda instance: getattr(instance, "last_certification_date", None) or datetime.datetime.min], processor="Get_certification_date")
         besoin_certification = columns.TextColumn("Demande de vérification en attente", sources=["besoin_certification"], processor="Format_bool")
         class Meta:
             structure_template = MyDatatable.structure_template

--- a/noethysweb/versions.txt
+++ b/noethysweb/versions.txt
@@ -1,3 +1,6 @@
+Version 1.3.5.6.71 (07/07/2026)
+- fix bug approbation tri date dernière vérification
+
 Version 1.3.5.6.70 (06/07/2026)
 - bug edtition pdf + pieces
 


### PR DESCRIPTION
## Problème

HTTP 500 sur `/utilisateur/individus/approbation/<activite>` lorsque la liste est triée par la colonne **Date de dernière vérification** :

```
TypeError: '<' not supported between instances of 'str' and 'datetime.datetime'
```

## Cause

La colonne `last_approbation` utilise `sources=["last_certification_date"]`, qui est une **annotation** de queryset (`Max(...)`) et non un champ réel du modèle. `datatableview` (2.1.6) ne la reconnaît pas comme champ triable en base et bascule sur un **tri en Python** (`datatables.py:789`).

Ce tri utilise la valeur source brute :
- inscription dont l'individu a une date de certification → un `datetime`
- inscription sans date → `Max(...)` renvoie `None`, remplacé par l'`empty_value` de datatableview, soit la **chaîne vide** `""` (`columns.py:126,207`)

Python tente alors de trier une liste mêlant `datetime` et `str` → crash.

## Correctif

La source de tri devient un callable qui renvoie **toujours** un `datetime`, en repliant le cas manquant sur `datetime.min` (côté Python) :

```python
last_approbation = columns.TextColumn(
    "Date de dernière vérification",
    sources=[lambda instance: getattr(instance, "last_certification_date", None) or datetime.datetime.min],
    processor="Get_certification_date",
)
```

Pourquoi c'est sûr :
- `USE_TZ = False` → tous les datetimes sont naïfs et comparables entre eux (pas de mélange naïf/aware).
- Le repli en Python (plutôt que via `Coalesce` SQL) évite les problèmes de plage de dates côté base (ex. plancher `DATETIME` de MySQL).
- L'affichage est inchangé : il est produit par le processor `Get_certification_date`, qui ignore la valeur source.

Les inscriptions sans date de vérification se trient désormais en bas (ordre croissant) / en haut (décroissant) au lieu de lever une 500.